### PR TITLE
Use Map instead of HashMap in ItemIdentifier.checkNBTbadness_recurse

### DIFF
--- a/common/logisticspipes/utils/ItemIdentifier.java
+++ b/common/logisticspipes/utils/ItemIdentifier.java
@@ -557,7 +557,7 @@ public final class ItemIdentifier implements Comparable<ItemIdentifier> {
 			Field fMap = ObfuscationHelper.getDeclaredField(NAMES.tagMap);
 			fMap.setAccessible(true);
 			@SuppressWarnings("unchecked")
-			HashMap<String, NBTBase> internal = (HashMap<String, NBTBase>) fMap.get(nbt);
+			Map<String, NBTBase> internal = (Map<String, NBTBase>) fMap.get(nbt);
 			for(Entry<String, NBTBase> e : internal.entrySet()) {
 				String k = e.getKey();
 				NBTBase v = e.getValue();


### PR DESCRIPTION
Fixes a class cast exception if tagMap isn't a HashMap, for example if it is a ConcurrentHashMap instance.

Signed-off-by: Ross Allan rallanpcl@gmail.com
