### PR TITLE
fixes #103 - make CC Interface more informative on requests

### DIFF
--- a/common/logisticspipes/pipes/PipeItemsRequestLogistics.java
+++ b/common/logisticspipes/pipes/PipeItemsRequestLogistics.java
@@ -184,12 +184,12 @@ outer:
 
 	@CCCommand(description="Requests the given ItemIdentifier Id with the given amount")
 	@CCQueued
-	public String makeRequest(Double itemId, Double amount) throws Exception {
+	public List makeRequest(Double itemId, Double amount) throws Exception {
 		return makeRequest(itemId, amount, false);
 	}
 	@CCCommand(description="Requests the given ItemIdentifier Id with the given amount")
 	@CCQueued
-	public String makeRequest(Double itemId, Double amount, Boolean forceCrafting) throws Exception {
+	public List makeRequest(Double itemId, Double amount, Boolean forceCrafting) throws Exception {
 		if(forceCrafting==null)
 			forceCrafting=false;
 		ItemIdentifier item = ItemIdentifier.getForId((int)Math.floor(itemId));


### PR DESCRIPTION
fixes #103 

makes it possible to get the result of the request (good or bad) like this:

crafting pipe behind computer

```
p = peripheral.wrap("back")

doCrafting = true

if doCrafting then
    print("Using Crafting")
    items = p.getCraftableItems()
else
    print("Using Provider")
    items = p.getAvailableItems()
end

for nr,item in ipairs(items) do
    if doCrafting then
        itemId = item
        itemCount = 1
    else
        itemId = item[1]
        itemCount = item[2]
    end

    name = p.getUnlocalizedName(itemId)

    print(itemId, ": ", p.getItemID(itemId), "#", p.getItemDamage(itemId), " = ", name, ": ", itemCount)

    result = p.makeRequest(itemId, itemCount, doCrafting)

    print(result[1])                     -- DONE/MISSING/NO_POWER
    for nr,item in ipairs(result[2]) do  -- the List of items requested/missing in the same list-format as getAvailableItems.
        print(p.getUnlocalizedName(item[1]), ": ", item[2])
    end

    print("")
    print("")
end
```

you can either set "doCrafting" to true or false

WARNING!!!! IT WILL REQUEST ALL ITEMS AVAILABLE!!!! SO ONLY USE IT FOR TESTING IN A SMALL NETWORK!!!

![crafting](https://f.cloud.github.com/assets/656249/721354/86300556-dfde-11e2-864d-a02ff0068a39.png)
![provider](https://f.cloud.github.com/assets/656249/721353/840862b4-dfde-11e2-86d0-d468db43af07.png)
