### PR TITLE
Fix Chassis Mk5 tooltip

### DIFF
--- a/resources/lang/logisticspipes/en_US.properties
+++ b/resources/lang/logisticspipes/en_US.properties
@@ -83,7 +83,7 @@ item.PipeLogisticsChassiMk4.tip2= - Can hold 4 modules.
 
 item.PipeLogisticsChassiMk5=Logistics Chassis Mk5
 item.PipeLogisticsChassiMk5.tip1=Type: Mixed
-item.PipeLogisticsChassiMk5.tip2= - Can hold 5 modules.
+item.PipeLogisticsChassiMk5.tip2= - Can hold 8 modules.
 
 item.PipeItemsRemoteOrdererLogistics=Remote Orderer Logistics Pipe
 item.PipeItemsRemoteOrdererLogistics.tip1=Type: Active requester

--- a/resources/lang/logisticspipes/pt_PT.properties
+++ b/resources/lang/logisticspipes/pt_PT.properties
@@ -84,7 +84,7 @@ item.PipeLogisticsChassiMk4.tip2= - Can hold 4 modules.
 
 item.PipeLogisticsChassiMk5=Logistics Chassis Mk5
 item.PipeLogisticsChassiMk5.tip1=Type: Mixed
-item.PipeLogisticsChassiMk5.tip2= - Can hold 5 modules.
+item.PipeLogisticsChassiMk5.tip2= - Can hold 8 modules.
 
 item.PipeItemsRemoteOrdererLogistics=Remote Orderer Logistics Pipe
 item.PipeItemsRemoteOrdererLogistics.tip1=Type: Active requester

--- a/resources/lang/logisticspipes/zh_CN.properties
+++ b/resources/lang/logisticspipes/zh_CN.properties
@@ -101,7 +101,7 @@ item.PipeLogisticsChassiMk4.tip2= - \u53ef\u4ee5\u5bb9\u7eb34\u4e2a\u6a21\u5757
 
 item.PipeLogisticsChassiMk5=\u7269\u6d41\u5e95\u76d8Mk5
 item.PipeLogisticsChassiMk5.tip1=\u7c7b\u578b: \u6df7\u5408
-item.PipeLogisticsChassiMk5.tip2= - \u53ef\u4ee5\u5bb9\u7eb35\u4e2a\u6a21\u5757
+item.PipeLogisticsChassiMk5.tip2= - \u53ef\u4ee5\u5bb9\u7eb38\u4e2a\u6a21\u5757
 
 item.PipeItemsRemoteOrdererLogistics=\u8fdc\u7a0b\u63d0\u8d27\u7269\u6d41\u7ba1\u9053
 item.PipeItemsRemoteOrdererLogistics.tip1=\u7c7b\u578b: \u4e3b\u52a8\u578b\u8bf7\u6c42


### PR DESCRIPTION
The tooltip for the Mk5 Chassis previously indicated that it has five slots, whereas it in fact has eight.  This commit fixes the tooltip.
