### PR TITLE
Fixed crash Issue @ mc16 with BC4.2.2 (+updated other mod bindings)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -34,16 +34,17 @@
 	<property name="mc.version"           value="1.6.4"/>
 	<property name="forge.version"        value="9.11.1.953"/>
 	<property name="forge.setup.version"  value="0"/> <!-- Change to regenerate Forge setup -->
-	<property name="bc.version"           value="4.2.1"/>
-	<property name="forestry.version"     value="2.3.0.0"/>
-	<property name="ic2.version"          value="2.0.143-experimental"/>
+	<property name="bc.version"           value="4.2.2"/>
+	<property name="forestry.version"     value="2.3.1.0"/>
+	<property name="ic2.version"          value="2.0.357-experimental"/>
 	<property name="cc.version"           value="1.56"/>
 	<property name="thaumcraft.version"   value="4.0.0"/>
 	<property name="lombok.version"       value="0.11.8"/>
 	<property name="jarjar.version"       value="1.4"/>
 	<property name="guava.version"        value="15.0-SNAPSHOT"/>
 	<property name="lp.version"           value="0.7.4"/>
-
+	<property name="lp.version.full"	value=""/>
+	
 	<!-- Targets -->
 	<target name="init-msg">
 		<echo message="Starting build for ${lp.version.full} for MC ${mc.version} for BC ${bc.version}"/>
@@ -53,9 +54,9 @@
 		<mkdir dir="${download.dir}"/>
 
 		<get src="http://files.minecraftforge.net/minecraftforge/minecraftforge-src-${mc.version}-${forge.version}.zip" dest="${download.dir}" usetimestamp="True"/>
-		<get src="${downloadserver.full}buildcraft-src-${bc.version}.zip" dest="${download.dir}" usetimestamp="True"/>
-		<get src="${downloadserver.full}forestry-api-${forestry.version}.zip" dest="${download.dir}" usetimestamp="True"/>
-		<get src="${downloadserver.full}industrialcraft-2-api_${ic2.version}.zip" dest="${download.dir}" usetimestamp="True"/>
+		<get src="http://mctech.sirius-black.org/external/buildcraft-src-${bc.version}.zip" dest="${download.dir}" usetimestamp="True"/>
+		<get src="http://mctech.sirius-black.org/external/forestry-api-${forestry.version}.zip" dest="${download.dir}" usetimestamp="True"/>
+		<get src="http://mctech.sirius-black.org/external/industrialcraft-2-api_${ic2.version}.zip" dest="${download.dir}" usetimestamp="True"/>
 		<get src="${downloadserver.full}ComputerCraftAPI${cc.version}.zip" dest="${download.dir}" usetimestamp="True"/>
 		<get src="${downloadserver.full}Thaumcraft${thaumcraft.version}-API.zip" dest="${download.dir}" usetimestamp="True"/>
 		<get src="${downloadserver.full}ant-contrib-${antcont.version}-bin.zip" dest="${download.dir}" usetimestamp="True"/>

--- a/common/logisticspipes/proxy/buildcraft/BuildCraftProxy.java
+++ b/common/logisticspipes/proxy/buildcraft/BuildCraftProxy.java
@@ -83,7 +83,7 @@ import buildcraft.core.utils.Utils;
 import buildcraft.transport.BlockGenericPipe;
 import buildcraft.transport.ItemPipe;
 import buildcraft.transport.Pipe;
-import buildcraft.transport.PipeTransportItems.TravelerSet;
+import buildcraft.transport.TravelerSet;
 import buildcraft.transport.TileGenericPipe;
 import buildcraft.transport.TransportProxy;
 import buildcraft.transport.TransportProxyClient;


### PR DESCRIPTION
Fixed crash issue with BuildCraft 4.2.2
(They moved a class to its own file / cleanup ..)

I Also updated the bindings to Forestry, IC2 and BuildCraft
to its most recent Versions.
