### PR TITLE
Fix UpgradeManager to save extra sneaky upgrades

### DIFF
--- a/common/logisticspipes/pipes/upgrades/UpgradeManager.java
+++ b/common/logisticspipes/pipes/upgrades/UpgradeManager.java
@@ -56,11 +56,15 @@ public class UpgradeManager implements ISimpleInventoryEventHandler {
 	public void readFromNBT(NBTTagCompound nbttagcompound) {
 		inv.readFromNBT(nbttagcompound, "UpgradeInventory_");
 		InventoryChanged(inv);
+		sneakyInv.readFromNBT(nbttagcompound, "SneakyUpgradeInventory_");
+		InventoryChanged(sneakyInv);
 	}
 	
 	public void writeToNBT(NBTTagCompound nbttagcompound) {
 		inv.writeToNBT(nbttagcompound, "UpgradeInventory_");
 		InventoryChanged(inv);
+		sneakyInv.writeToNBT(nbttagcompound, "SneakyUpgradeInventory_");
+		InventoryChanged(sneakyInv);
 	}
 
 	private boolean updateModule(int slot, IPipeUpgrade[] upgrades, IInventory inv) {
@@ -253,6 +257,7 @@ public class UpgradeManager implements ISimpleInventoryEventHandler {
 	
 	public void dropUpgrades() {
 		inv.dropContents(pipe.getWorld(), pipe.getX(), pipe.getY(), pipe.getZ());
+		sneakyInv.dropContents(pipe.getWorld(), pipe.getX(), pipe.getY(), pipe.getZ());
 	}
 
 	public boolean isSideDisconnected(ForgeDirection side) {


### PR DESCRIPTION
UpgradeManager did not read and write the sneakyInv inventory to NBT and did not drop the contents of it when broken.

I have not tested this as I do not have a working MCP environment set up. The changes are simple though, and I hope someone will look over them and test it. This should fix #770
