### PR TITLE
Remove unnecessary NetworkMod annotation

### DIFF
--- a/common/logisticspipes/LogisticsPipes.java
+++ b/common/logisticspipes/LogisticsPipes.java
@@ -123,10 +123,6 @@ import cpw.mods.fml.relauncher.Side;
 				"after:AppliedEnergistics;" +
 				"after:ThermalExpansion;" +
 				"after:BetterStorage")
-@NetworkMod(
-		channels = {LogisticsPipes.LOGISTICS_PIPES_CHANNEL_NAME},
-		packetHandler = PacketHandler.class,
-		clientSideRequired = true)
 public class LogisticsPipes {
 
 	public LogisticsPipes() {


### PR DESCRIPTION
It's not needed anymore, and it isn't even in the imports.
