### PR TITLE
Added Version Checker integration

### DIFF
--- a/common/logisticspipes/LogisticsEventListener.java
+++ b/common/logisticspipes/LogisticsEventListener.java
@@ -179,7 +179,7 @@ public class LogisticsEventListener {
 			SimpleServiceLocator.securityStationManager.sendClientAuthorizationList(event.player);
 			SimpleServiceLocator.craftingPermissionManager.sendCraftingPermissionsToPlayer(event.player);
 		}
-		if(VersionChecker.hasNewVersion) {
+		if(VersionChecker.hasNewVersion && !VersionChecker.sentIMCMessage) {
 			event.player.addChatComponentMessage(new ChatComponentText("Your LogisticsPipes version is outdated. The newest version is #" + VersionChecker.newVersion + "."));
 			event.player.addChatComponentMessage(new ChatComponentText("Use \"/logisticspipes changelog\" to see a changelog."));
 		}

--- a/common/logisticspipes/ticks/VersionChecker.java
+++ b/common/logisticspipes/ticks/VersionChecker.java
@@ -92,17 +92,21 @@ public class VersionChecker extends Thread {
 		}
 	}
 
+    /**
+     * Integration with Version Checker (http://www.minecraftforum.net/topic/2721902-/)
+     */
 	public static void sendIMCOutdatedMessage() {
 		NBTTagCompound tag = new NBTTagCompound();
+		tag.setString("oldVersion", LogisticsPipes.VERSION);
 		tag.setString("newVersion", newVersion);
-		tag.setString("updateUrl", "http://www.minecraftforum.net/topic/1831791-/#downloads");
+		tag.setString("updateUrl", "http://ci.thezorro266.com/view/Logistics%20Pipes/");
 		tag.setBoolean("isDirectLink", false);
 
-		String changeLogString = "";
+		StringBuilder stringBuilder = new StringBuilder();
 		for (String changeLogLine : changeLog) {
-			changeLogString = changeLogString + changeLogLine + "\n";
+			stringBuilder.append(changeLogLine).append("\n");
 		}
-		tag.setString("changeLog", changeLogString);
+		tag.setString("changeLog", stringBuilder.toString());
 		sentIMCMessage = FMLInterModComms.sendMessage("VersionChecker", "addUpdate", tag);
 	}
 }

--- a/common/logisticspipes/ticks/VersionChecker.java
+++ b/common/logisticspipes/ticks/VersionChecker.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.event.FMLInterModComms;
 import logisticspipes.Configs;
 import logisticspipes.LogisticsPipes;
@@ -92,21 +93,24 @@ public class VersionChecker extends Thread {
 		}
 	}
 
-    /**
-     * Integration with Version Checker (http://www.minecraftforum.net/topic/2721902-/)
-     */
+	/**
+	 * Integration with Version Checker (http://www.minecraftforum.net/topic/2721902-/)
+	 */
 	public static void sendIMCOutdatedMessage() {
-		NBTTagCompound tag = new NBTTagCompound();
-		tag.setString("oldVersion", LogisticsPipes.VERSION);
-		tag.setString("newVersion", newVersion);
-		tag.setString("updateUrl", "http://ci.thezorro266.com/view/Logistics%20Pipes/");
-		tag.setBoolean("isDirectLink", false);
+		if (Loader.isModLoaded("VersionChecker")) {
+			NBTTagCompound tag = new NBTTagCompound();
+			tag.setString("oldVersion", LogisticsPipes.VERSION);
+			tag.setString("newVersion", newVersion);
+			tag.setString("updateUrl", "http://ci.thezorro266.com/view/Logistics%20Pipes/");
+			tag.setBoolean("isDirectLink", false);
 
-		StringBuilder stringBuilder = new StringBuilder();
-		for (String changeLogLine : changeLog) {
-			stringBuilder.append(changeLogLine).append("\n");
+			StringBuilder stringBuilder = new StringBuilder();
+			for (String changeLogLine : changeLog) {
+				stringBuilder.append(changeLogLine).append("\n");
+			}
+			tag.setString("changeLog", stringBuilder.toString());
+			FMLInterModComms.sendRuntimeMessage("LogisticsPipes", "VersionChecker", "addUpdate", tag);
+			sentIMCMessage = true;
 		}
-		tag.setString("changeLog", stringBuilder.toString());
-		sentIMCMessage = FMLInterModComms.sendMessage("VersionChecker", "addUpdate", tag);
 	}
 }

--- a/common/logisticspipes/ticks/VersionChecker.java
+++ b/common/logisticspipes/ticks/VersionChecker.java
@@ -9,16 +9,19 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
+import cpw.mods.fml.common.event.FMLInterModComms;
 import logisticspipes.Configs;
 import logisticspipes.LogisticsPipes;
 
 import com.google.gson.Gson;
+import net.minecraft.nbt.NBTTagCompound;
 
 public class VersionChecker extends Thread {
 
 	public static boolean hasNewVersion = false;
 	public static String newVersion = "";
 	public static List<String> changeLog = new ArrayList<String>(0);
+	public static boolean sentIMCMessage;
 
 	public VersionChecker() {
 		this.setDaemon(true);
@@ -76,6 +79,7 @@ public class VersionChecker extends Thread {
 					}
 				}
 				VersionChecker.changeLog = changeLogList;
+				sendIMCOutdatedMessage();
 			}
 		} catch(MalformedURLException e) {
 			if (Configs.CHECK_FOR_UPDATES){
@@ -86,5 +90,19 @@ public class VersionChecker extends Thread {
 				e.printStackTrace();
 			}
 		}
+	}
+
+	public static void sendIMCOutdatedMessage() {
+		NBTTagCompound tag = new NBTTagCompound();
+		tag.setString("newVersion", newVersion);
+		tag.setString("updateUrl", "http://www.minecraftforum.net/topic/1831791-/#downloads");
+		tag.setBoolean("isDirectLink", false);
+
+		String changeLogString = "";
+		for (String changeLogLine : changeLog) {
+			changeLogString = changeLogString + changeLogLine + "\n";
+		}
+		tag.setString("changeLog", changeLogString);
+		sentIMCMessage = FMLInterModComms.sendMessage("VersionChecker", "addUpdate", tag);
 	}
 }


### PR DESCRIPTION
This PR adds integration with Version Checker (http://www.minecraftforum.net/topic/2721902-172version-checker). This is a small mod giving users a list of outdated mods, with options to easily update.

This adds a simple IMC message to Version Checker, which will then handle everything automatically. This does not create a dependency! The update message at startup is not shown when the IMC message has successfully been sent.

Preferably we should use a direct link to the new mod file, but I first need to know if this is something you want and what the best way is to get this link. This will allow users to update with a click on a button and a restart!

I know the 1.7 branch isn't finished yet (and both the edited files have errors), but it would be nice to have integration when the first 1.7 build is released :) 
