### PR TITLE
Use OreDict for gears in our recipes.

### DIFF
--- a/common/logisticspipes/recipes/RecipeManager.java
+++ b/common/logisticspipes/recipes/RecipeManager.java
@@ -78,7 +78,7 @@ public class RecipeManager {
 			"grg",
 			"cdc",
 			" G ",
-			Character.valueOf('G'), BuildCraftCore.goldGearItem,
+			Character.valueOf('G'), "gearGold",
 			Character.valueOf('g'), Block.glass,
 			Character.valueOf('d'), BuildCraftTransport.pipeItemsDiamond,
 			Character.valueOf('c'), BuildCraftTransport.pipeItemsCobblestone,
@@ -89,7 +89,7 @@ public class RecipeManager {
 			" G ",
 			"rPr",
 			Character.valueOf('P'), LogisticsPipes.LogisticsBasicPipe,
-			Character.valueOf('G'), BuildCraftCore.goldGearItem,
+			Character.valueOf('G'), "gearGold",
 			Character.valueOf('r'), Item.redstone
 		});
 
@@ -106,7 +106,7 @@ public class RecipeManager {
 			"U",
 			"B",
 			Character.valueOf('B'), LogisticsPipes.LogisticsProviderPipeMk1,
-			Character.valueOf('U'), BuildCraftCore.diamondGearItem
+			Character.valueOf('U'), "gearDiamond"
 		});
 		
 		craftingManager.addRecipe(new ItemStack(LogisticsPipes.LogisticsProviderPipeMk2, 1), CraftingDependency.Fast_Crafting, new Object[] {
@@ -121,7 +121,7 @@ public class RecipeManager {
 			"P",
 			"S",
 			Character.valueOf('P'), LogisticsPipes.LogisticsBasicPipe,
-			Character.valueOf('S'), BuildCraftCore.stoneGearItem,
+			Character.valueOf('S'), "gearStone",
 			Character.valueOf('r'), Item.redstone
 		});
 		
@@ -142,8 +142,8 @@ public class RecipeManager {
 			"P",
 			"i",
 			Character.valueOf('P'), LogisticsPipes.LogisticsBasicPipe,
-			Character.valueOf('g'), BuildCraftCore.goldGearItem,
-			Character.valueOf('i'), BuildCraftCore.ironGearItem
+			Character.valueOf('g'), "gearGold",
+			Character.valueOf('i'), "gearIron"
 		});
 
 		craftingManager.addRecipe(new ItemStack(LogisticsPipes.LogisticsRequestPipeMk1, 1), CraftingDependency.Basic, new Object[] {
@@ -152,7 +152,7 @@ public class RecipeManager {
 			"i",
 			Character.valueOf('P'), LogisticsPipes.LogisticsBasicPipe,
 			Character.valueOf('g'), new ItemStack(BuildCraftSilicon.redstoneChipset, 1, 2),
-			Character.valueOf('i'), BuildCraftCore.ironGearItem
+			Character.valueOf('i'), "gearIron"
 		});
 
 		craftingManager.addRecipe(new ItemStack(LogisticsPipes.LogisticsRequestPipeMk2, 1), CraftingDependency.Fast_Crafting, new Object[] {
@@ -160,7 +160,7 @@ public class RecipeManager {
 			"B",
 			"r",
 			Character.valueOf('B'), LogisticsPipes.LogisticsRequestPipeMk1,
-			Character.valueOf('U'), BuildCraftCore.diamondGearItem,
+			Character.valueOf('U'), "gearDiamond",
 			Character.valueOf('r'), Item.redstone
 		});
 		
@@ -176,7 +176,7 @@ public class RecipeManager {
 			"B",
 			"r",
 			Character.valueOf('B'), LogisticsPipes.LogisticsCraftingPipeMk1,
-			Character.valueOf('U'), BuildCraftCore.goldGearItem,
+			Character.valueOf('U'), "gearGold",
 			Character.valueOf('r'), Item.redstone
 		});
 		
@@ -240,7 +240,7 @@ public class RecipeManager {
 			"CGC",
 			"rBr",
 			Character.valueOf('C'), "dyeGreen",
-			Character.valueOf('G'), BuildCraftCore.ironGearItem,
+			Character.valueOf('G'), "gearIron",
 			Character.valueOf('r'), Item.redstone,
 			Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.BLANK)
 		});
@@ -257,7 +257,7 @@ public class RecipeManager {
 			"CGC",
 			"rBr",
 			Character.valueOf('C'), "dyeRed",
-			Character.valueOf('G'), BuildCraftCore.ironGearItem,
+			Character.valueOf('G'), "gearIron",
 			Character.valueOf('r'), Item.redstone,
 			Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.BLANK)
 		});
@@ -274,7 +274,7 @@ public class RecipeManager {
 			"CGC",
 			"rBr",
 			Character.valueOf('C'), "dyeBlue",
-			Character.valueOf('G'), BuildCraftCore.ironGearItem,
+			Character.valueOf('G'), "gearIron",
 			Character.valueOf('r'), Item.redstone,
 			Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.BLANK)
 		});
@@ -298,7 +298,7 @@ public class RecipeManager {
 			"U",
 			"B",
 			Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.EXTRACTOR),
-			Character.valueOf('U'), BuildCraftCore.goldGearItem
+			Character.valueOf('U'), "gearGold"
 		});
 		
 		craftingManager.addRecipe(new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.EXTRACTOR_MK2), CraftingDependency.High_Tech_Modules, new Object[] {
@@ -312,7 +312,7 @@ public class RecipeManager {
 			"U",
 			"B",
 			Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.ADVANCED_EXTRACTOR),
-			Character.valueOf('U'), BuildCraftCore.goldGearItem
+			Character.valueOf('U'), "gearGold"
 		});
 		
 		craftingManager.addRecipe(new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.ADVANCED_EXTRACTOR_MK2), CraftingDependency.High_Tech_Modules, new Object[] {
@@ -333,7 +333,7 @@ public class RecipeManager {
 			"U",
 			"B",
 			Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.EXTRACTOR_MK2),
-			Character.valueOf('U'), BuildCraftCore.diamondGearItem
+			Character.valueOf('U'), "gearDiamond"
 		});
 		
 		craftingManager.addRecipe(new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.EXTRACTOR_MK3), CraftingDependency.High_Tech_Modules, new Object[] {
@@ -347,7 +347,7 @@ public class RecipeManager {
 			"U",
 			"B",
 			Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.ADVANCED_EXTRACTOR_MK2),
-			Character.valueOf('U'), BuildCraftCore.diamondGearItem
+			Character.valueOf('U'), "gearDiamond"
 		});
 		
 		craftingManager.addRecipe(new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.ADVANCED_EXTRACTOR_MK3), CraftingDependency.High_Tech_Modules, new Object[] {
@@ -368,7 +368,7 @@ public class RecipeManager {
 			"CGC",
 			"rBr",
 			Character.valueOf('C'), "dyeOrange",
-			Character.valueOf('G'), BuildCraftCore.ironGearItem,
+			Character.valueOf('G'), "gearIron",
 			Character.valueOf('r'), Item.redstone,
 			Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.BLANK)
 		});
@@ -385,7 +385,7 @@ public class RecipeManager {
 			"CGC",
 			"rBr",
 			Character.valueOf('C'), "dyeBlue",
-			Character.valueOf('G'), BuildCraftCore.diamondGearItem,
+			Character.valueOf('G'), "gearDiamond",
 			Character.valueOf('r'), Item.redstone,
 			Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.BLANK)
 		});
@@ -403,7 +403,7 @@ public class RecipeManager {
 			"rBr",
 			Character.valueOf('C'), "dyeBlack",
 			Character.valueOf('D'), "dyePurple",
-			Character.valueOf('G'), BuildCraftCore.ironGearItem,
+			Character.valueOf('G'), "gearIron",
 			Character.valueOf('r'), Item.redstone,
 			Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.BLANK)
 		});
@@ -421,7 +421,7 @@ public class RecipeManager {
 			"CGC",
 			"rBr",
 			Character.valueOf('C'), "dyeBlue",
-			Character.valueOf('G'), BuildCraftCore.goldGearItem,
+			Character.valueOf('G'), "gearGold",
 			Character.valueOf('r'), Item.redstone,
 			Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.BLANK)
 		});
@@ -438,7 +438,7 @@ public class RecipeManager {
 			"U",
 			"B",
 			Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.PROVIDER),
-			Character.valueOf('U'), BuildCraftCore.diamondGearItem
+			Character.valueOf('U'), "gearDiamond"
 		});
 		
 		craftingManager.addRecipe(new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.PROVIDER_MK2), CraftingDependency.High_Tech_Modules, new Object[] {
@@ -452,7 +452,7 @@ public class RecipeManager {
 			"U",
 			"B",
 			Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.ITEMSINK),
-			Character.valueOf('U'), BuildCraftCore.goldGearItem
+			Character.valueOf('U'), "gearGold"
 		});
 
 		craftingManager.addRecipe(new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.MODBASEDITEMSINK), CraftingDependency.Sink_Modules, new Object[] {
@@ -485,7 +485,7 @@ public class RecipeManager {
 		craftingManager.addRecipe(new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.ENCHANTMENTSINK_MK2), CraftingDependency.Sink_Modules, new Object[] {
 			"U",
 			"B",
-			Character.valueOf('U'), BuildCraftCore.goldGearItem,
+			Character.valueOf('U'), "gearGold",
 			Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.ENCHANTMENTSINK)
 		});
 		
@@ -584,7 +584,7 @@ public class RecipeManager {
 			" G ",
 			" g ",
 			Character.valueOf('g'), Item.ingotGold,
-			Character.valueOf('G'), BuildCraftCore.goldGearItem
+			Character.valueOf('G'), "gearGold"
 		});
 		
 		craftingManager.addRecipe(new ItemStack(LogisticsPipes.LogisticsNetworkMonitior, 1), CraftingDependency.Basic, new Object[] {
@@ -600,7 +600,7 @@ public class RecipeManager {
 			"gg",
 			"DD",
 			Character.valueOf('g'), Block.glass,
-			Character.valueOf('D'), BuildCraftCore.diamondGearItem
+			Character.valueOf('D'), "gearDiamond"
 		});
 		
 		craftingManager.addRecipe(new ItemStack(LogisticsPipes.LogisticsRemoteOrderer, 1, 0), CraftingDependency.DistanceRequest, new Object[] {
@@ -644,9 +644,9 @@ public class RecipeManager {
 			"G G",
 			" S ",
 			" D ",
-			Character.valueOf('G'), BuildCraftCore.goldGearItem,
+			Character.valueOf('G'), "gearGold",
 			Character.valueOf('S'), Item.sign,
-			Character.valueOf('D'), BuildCraftCore.diamondGearItem
+			Character.valueOf('D'), "gearDiamond"
 		});
 		
 		craftingManager.addRecipe(new ItemStack(LogisticsPipes.LogisticsCraftingSignCreator, 1), CraftingDependency.Information_System, new Object[] {
@@ -680,7 +680,7 @@ public class RecipeManager {
 			"iDi",
 			"rBr",
 			"iii",
-			Character.valueOf('D'), new ItemStack(BuildCraftCore.diamondGearItem, 1),
+			Character.valueOf('D'), "gearDiamond",
 			Character.valueOf('r'), Item.redstone,
 			Character.valueOf('B'), LogisticsPipes.LogisticsBasicPipe,
 			Character.valueOf('i'), Item.ingotIron
@@ -703,7 +703,7 @@ public class RecipeManager {
 			Character.valueOf('w'), "plankWood",
 			Character.valueOf('C'), Block.workbench,
 			Character.valueOf('S'), Block.chest,
-			Character.valueOf('G'), BuildCraftCore.stoneGearItem
+			Character.valueOf('G'), "gearStone"
 		});
 		
 		craftingManager.addRecipe(new ItemStack(LogisticsPipes.LogisticsSolidBlock, 1, LogisticsSolidBlock.LOGISTICS_FUZZYCRAFTING_TABLE), CraftingDependency.Basic, new Object[] { 
@@ -843,7 +843,7 @@ public class RecipeManager {
 			"RgR", 
 			Character.valueOf('C'), new ItemStack(BuildCraftSilicon.redstoneChipset, 1, 1),
 			Character.valueOf('R'), Item.redstone, 
-			Character.valueOf('g'), BuildCraftCore.woodenGearItem, 
+			Character.valueOf('g'), "gearWood"
 		});
 		
 		craftingManager.addRecipe(new ItemStack(LogisticsPipes.UpgradeItem, 1, 10), CraftingDependency.Upgrades, new Object[] { 


### PR DESCRIPTION
BC is nice enough to register oredict names for them.
PRed because this could affect balance in packs that don't expect this.
