### PR TITLE
Add special connection for new EnderIO's Dimensional Transceiver

### DIFF
--- a/common/logisticspipes/LogisticsPipes.java
+++ b/common/logisticspipes/LogisticsPipes.java
@@ -86,6 +86,7 @@ import logisticspipes.proxy.recipeproviders.LogisticsCraftingTable;
 import logisticspipes.proxy.recipeproviders.RollingMachine;
 import logisticspipes.proxy.recipeproviders.SolderingStation;
 import logisticspipes.proxy.specialconnection.EnderIOHyperCubeConnection;
+import logisticspipes.proxy.specialconnection.EnderIOTransceiverConnection;
 import logisticspipes.proxy.specialconnection.SpecialPipeConnection;
 import logisticspipes.proxy.specialconnection.SpecialTileConnection;
 import logisticspipes.proxy.specialconnection.TeleportPipes;
@@ -364,7 +365,8 @@ public class LogisticsPipes {
 		SimpleServiceLocator.specialpipeconnection.registerHandler(new TeleportPipes());
 		SimpleServiceLocator.specialtileconnection.registerHandler(new TesseractConnection());
 		SimpleServiceLocator.specialtileconnection.registerHandler(new EnderIOHyperCubeConnection());
-		
+		SimpleServiceLocator.specialtileconnection.registerHandler(new EnderIOTransceiverConnection());
+
 		Object renderer = null;
 		if(isClient) {
 			renderer = new FluidContainerRenderer();

--- a/common/logisticspipes/interfaces/routing/ISpecialTileConnection.java
+++ b/common/logisticspipes/interfaces/routing/ISpecialTileConnection.java
@@ -1,14 +1,14 @@
 package logisticspipes.interfaces.routing;
 
-import java.util.List;
-
 import logisticspipes.logisticspipes.IRoutedItem;
 import net.minecraft.tileentity.TileEntity;
+
+import java.util.Collection;
 
 public interface ISpecialTileConnection {
 	public boolean init();
 	public boolean isType(TileEntity tile);
-	public List<TileEntity> getConnections(TileEntity tile);
+	public Collection<TileEntity> getConnections(TileEntity tile);
 	public boolean needsInformationTransition();
 	public void transmit(TileEntity tile, IRoutedItem arrivingItem);
 }

--- a/common/logisticspipes/pipes/basic/CoreRoutedPipe.java
+++ b/common/logisticspipes/pipes/basic/CoreRoutedPipe.java
@@ -9,9 +9,11 @@
 package logisticspipes.pipes.basic;
 
 import java.io.IOException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -19,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
+import java.util.TreeMap;
+import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.PriorityBlockingQueue;
@@ -120,6 +124,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import sun.java2d.opengl.OGLRenderQueue;
 
 @CCType(name = "LogisticsPipes:Normal")
 public abstract class CoreRoutedPipe extends CoreUnroutedPipe implements IClientState, IRequestItems, IAdjacentWorldAccess, ITrackStatistics, IWorldProvider, IWatchingHandler, IPipeServiceProvider, IQueueCCEvent {
@@ -169,7 +174,7 @@ public abstract class CoreRoutedPipe extends CoreUnroutedPipe implements IClient
 	
 	protected final LinkedList<Triplet<IRoutedItem, ForgeDirection, ItemSendMode>> _sendQueue = new LinkedList<Triplet<IRoutedItem, ForgeDirection, ItemSendMode>>();
 	
-	protected final Map<ItemIdentifierStack, ItemRoutingInformation> queuedDataForUnroutedItems = new HashMap<ItemIdentifierStack, ItemRoutingInformation>();
+	protected final Map<ItemIdentifier, Queue<Pair<Integer, ItemRoutingInformation>>> queuedDataForUnroutedItems = Collections.synchronizedMap(new TreeMap<ItemIdentifier, Queue<Pair<Integer, ItemRoutingInformation>>>());
 	
 	public final PlayerCollectionList watchers = new PlayerCollectionList();
 
@@ -1188,14 +1193,36 @@ outer:
 
 	public void queueUnroutedItemInformation(ItemIdentifierStack item, ItemRoutingInformation informaiton) {
 		if(item != null) {
-			queuedDataForUnroutedItems.put(item, informaiton);
+			synchronized (queuedDataForUnroutedItems) {
+				Queue<Pair<Integer, ItemRoutingInformation>> queue = queuedDataForUnroutedItems.get(item.getItem());
+				if (queue == null) {
+					queuedDataForUnroutedItems.put(item.getItem(), queue = new LinkedList<Pair<Integer, ItemRoutingInformation>>());
+				}
+				queue.add(new Pair<Integer, ItemRoutingInformation>(item.getStackSize(), informaiton));
+			}
 		}
 	}
 	
-	public ItemRoutingInformation getQueuedForItemStack(ItemIdentifierStack itemIdentifierStack) {
-		for(ItemIdentifierStack item:queuedDataForUnroutedItems.keySet()) {
-			if(item.equals(itemIdentifierStack)) {
-				return queuedDataForUnroutedItems.remove(item);
+	public ItemRoutingInformation getQueuedForItemStack(ItemIdentifierStack item) {
+		synchronized (queuedDataForUnroutedItems) {
+			Queue<Pair<Integer, ItemRoutingInformation>> queue = queuedDataForUnroutedItems.get(item.getItem());
+			if (queue == null || queue.isEmpty()) {
+				return null;
+			}
+
+			Pair<Integer, ItemRoutingInformation> pair = queue.peek();
+			int wantItem = pair.getValue1();
+
+			if (wantItem <= item.getStackSize()) {
+				if (queue.remove() != pair) {
+					LogisticsPipes.log.fatal("Item queue mismatch");
+					return null;
+				}
+				if (queue.isEmpty()) {
+					queuedDataForUnroutedItems.remove(item.getItem());
+				}
+				item.setStackSize(wantItem);
+				return pair.getValue2();
 			}
 		}
 		return null;

--- a/common/logisticspipes/proxy/ProxyManager.java
+++ b/common/logisticspipes/proxy/ProxyManager.java
@@ -306,7 +306,9 @@ public class ProxyManager {
 		SimpleServiceLocator.setEnderIOProxy(getWrappedProxy("EnderIO", IEnderIOProxy.class, EnderIOProxy.class, new IEnderIOProxy() {
 			@Override public boolean isSendAndReceive(TileEntity tile) {return false;}
 			@Override public boolean isHyperCube(TileEntity tile) {return false;}
+			@Override public boolean isTransceiver(TileEntity tile) {return false;}
 			@Override public List<TileEntity> getConnectedHyperCubes(TileEntity tile) {return new ArrayList<TileEntity>(0);}
+			@Override public List<TileEntity> getConnectedTransceivers(TileEntity tile) {return null;}
 			@Override public boolean isEnderIO() {return false;}
 		}));
 

--- a/common/logisticspipes/proxy/enderio/EnderIOProxy.java
+++ b/common/logisticspipes/proxy/enderio/EnderIOProxy.java
@@ -3,6 +3,10 @@ package logisticspipes.proxy.enderio;
 import java.util.ArrayList;
 import java.util.List;
 
+import crazypants.enderio.machine.transceiver.Channel;
+import crazypants.enderio.machine.transceiver.ChannelType;
+import crazypants.enderio.machine.transceiver.ServerChannelRegister;
+import crazypants.enderio.machine.transceiver.TileTransceiver;
 import logisticspipes.proxy.interfaces.IEnderIOProxy;
 import net.minecraft.tileentity.TileEntity;
 import crazypants.enderio.machine.hypercube.HyperCubeRegister;
@@ -18,6 +22,11 @@ public class EnderIOProxy implements IEnderIOProxy {
 	}
 
 	@Override
+	public boolean isTransceiver(TileEntity tile) {
+		return tile instanceof TileTransceiver;
+	}
+
+	@Override
 	public List<TileEntity> getConnectedHyperCubes(TileEntity tile) {
 		List<TileHyperCube> cons = HyperCubeRegister.instance.getCubesForChannel(((TileHyperCube)tile).getChannel());
 		List<TileEntity> tiles = new ArrayList<TileEntity>();
@@ -30,8 +39,34 @@ public class EnderIOProxy implements IEnderIOProxy {
 	}
 
 	@Override
+	public List<TileEntity> getConnectedTransceivers(TileEntity tile) {
+		TileTransceiver transceiver = (TileTransceiver) tile;
+		List<TileEntity> tiles = new ArrayList<TileEntity>();
+		Channel channel = transceiver.getRecieveChannels(ChannelType.ITEM).get(0);
+		for (TileTransceiver t : ServerChannelRegister.instance.getIterator(channel)) {
+			if (t == transceiver) {
+				continue;
+			}
+			List<Channel> receiveChannels = t.getRecieveChannels(ChannelType.ITEM);
+			List<Channel> sendChannels = t.getSendChannels(ChannelType.ITEM);
+			if (receiveChannels.size() == 1 && sendChannels.size() == 1 && channel.equals(receiveChannels.get(0)) && channel.equals(sendChannels.get(0))) {
+				tiles.add(t);
+			}
+		}
+		return tiles;
+	}
+
+	@Override
 	public boolean isSendAndReceive(TileEntity tile) {
-		return IoMode.BOTH == ((TileHyperCube)tile).getModeForChannel(SubChannel.ITEM);
+		if (tile instanceof TileHyperCube) {
+			return IoMode.BOTH == ((TileHyperCube) tile).getModeForChannel(SubChannel.ITEM);
+		}
+		if (tile instanceof TileTransceiver) {
+			List<Channel> receiveChannels = ((TileTransceiver) tile).getRecieveChannels(ChannelType.ITEM);
+			List<Channel> sendChannels = ((TileTransceiver) tile).getSendChannels(ChannelType.ITEM);
+			return receiveChannels.size() == 1 && sendChannels.size() == 1 && receiveChannels.get(0).equals(sendChannels.get(0));
+		}
+		return false;
 	}
 	
 	@Override

--- a/common/logisticspipes/proxy/interfaces/IEnderIOProxy.java
+++ b/common/logisticspipes/proxy/interfaces/IEnderIOProxy.java
@@ -6,7 +6,9 @@ import net.minecraft.tileentity.TileEntity;
 
 public interface IEnderIOProxy {
 	public boolean isHyperCube(TileEntity tile);
+	public boolean isTransceiver(TileEntity tile);
 	public List<TileEntity> getConnectedHyperCubes(TileEntity tile);
+	public List<TileEntity> getConnectedTransceivers(TileEntity tile);
 	public boolean isSendAndReceive(TileEntity tile);
 	public boolean isEnderIO();
 }

--- a/common/logisticspipes/proxy/specialconnection/EnderIOTransceiverConnection.java
+++ b/common/logisticspipes/proxy/specialconnection/EnderIOTransceiverConnection.java
@@ -1,40 +1,41 @@
 package logisticspipes.proxy.specialconnection;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import logisticspipes.interfaces.routing.ISpecialTileConnection;
 import logisticspipes.logisticspipes.IRoutedItem;
 import logisticspipes.pipes.basic.CoreRoutedPipe;
 import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import logisticspipes.proxy.MainProxy;
 import logisticspipes.proxy.SimpleServiceLocator;
-import logisticspipes.utils.item.ItemIdentifier;
-import logisticspipes.utils.item.ItemIdentifierStack;
 import logisticspipes.utils.tuples.LPPosition;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class TesseractConnection implements ISpecialTileConnection {
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class EnderIOTransceiverConnection implements ISpecialTileConnection {
 	
 	@Override
 	public boolean init() {
-		return SimpleServiceLocator.thermalExpansionProxy.isTE();
+		return SimpleServiceLocator.enderIOProxy.isEnderIO();
 	}
 
 	@Override
 	public boolean isType(TileEntity tile) {
-		return SimpleServiceLocator.thermalExpansionProxy.isTesseract(tile);
+		return SimpleServiceLocator.enderIOProxy.isTransceiver(tile);
 	}
 
 	@Override
-	public List<TileEntity> getConnections(TileEntity tile) {
+	public Collection<TileEntity> getConnections(TileEntity tile) {
 		boolean onlyOnePipe = false;
 		for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
 			LPPosition p = new LPPosition(tile);
 			p.moveForward(direction);
-			TileEntity canidate = p.getTileEntity(tile.getWorldObj());
-			if(canidate instanceof LogisticsTileGenericPipe && MainProxy.checkPipesConnections(tile, canidate, direction)) {
+			TileEntity candidate = p.getTileEntity(tile.getWorldObj());
+			if (candidate instanceof LogisticsTileGenericPipe && MainProxy.checkPipesConnections(tile, candidate, direction)) {
 				if(onlyOnePipe) {
 					onlyOnePipe = false;
 					break;
@@ -43,33 +44,33 @@ public class TesseractConnection implements ISpecialTileConnection {
 				}
 			}
 		}
-		if(!onlyOnePipe) {
+		if(!onlyOnePipe || !SimpleServiceLocator.enderIOProxy.isSendAndReceive(tile)) {
 			return new ArrayList<TileEntity>(0);
 		}
-		List<? extends TileEntity> connections = SimpleServiceLocator.thermalExpansionProxy.getConnectedTesseracts(tile);
-		connections.remove(tile);
-		List<TileEntity> list = new ArrayList<TileEntity>();
+		List<? extends TileEntity> connections = SimpleServiceLocator.enderIOProxy.getConnectedTransceivers(tile);
+		Set<TileEntity> set = new HashSet<TileEntity>();
 		for(TileEntity connected:connections) {
+			if(!SimpleServiceLocator.enderIOProxy.isSendAndReceive(connected)) continue;
 			LogisticsTileGenericPipe pipe = null;
 			for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
 				LPPosition p = new LPPosition(connected);
 				p.moveForward(direction);
-				TileEntity canidate = p.getTileEntity(tile.getWorldObj());
-				if(canidate instanceof LogisticsTileGenericPipe && MainProxy.checkPipesConnections(connected, canidate, direction)) {
+				TileEntity candidate = p.getTileEntity(tile.getWorldObj());
+				if (candidate instanceof LogisticsTileGenericPipe && MainProxy.checkPipesConnections(connected, candidate, direction)) {
 					if(pipe != null) {
 						pipe = null;
 						break;
 					} else {
-						pipe = (LogisticsTileGenericPipe) canidate;
+						pipe = (LogisticsTileGenericPipe) candidate;
 					}
 				}
 			}
 			if(pipe != null && pipe.pipe instanceof CoreRoutedPipe) {
-				list.add(pipe);
+				set.add(pipe);
 			}
 		}
-		if(list.size() == 1) {
-			return list;
+		if(set.size() == 1) {
+			return set;
 		} else {
 			return new ArrayList<TileEntity>(0);
 		}
@@ -82,13 +83,13 @@ public class TesseractConnection implements ISpecialTileConnection {
 
 	@Override
 	public void transmit(TileEntity tile, IRoutedItem data) {
-		List<TileEntity> list = getConnections(tile);
+		Collection<TileEntity> list = getConnections(tile);
 		if(list.size() < 1) return;
-		TileEntity pipe = list.get(0);
+		TileEntity pipe = list.iterator().next();
 		if(pipe instanceof LogisticsTileGenericPipe) {
 			((CoreRoutedPipe)((LogisticsTileGenericPipe)pipe).pipe).queueUnroutedItemInformation(data.getItemIdentifierStack().clone(), data.getInfo());
 		} else {
-			new RuntimeException("Only LP pipes can be next to Teseracts to queue item informaiton").printStackTrace();
+			new RuntimeException("Only LP pipes can be next to transceiver to queue item information").printStackTrace();
 		}
 	}
 }

--- a/common/logisticspipes/proxy/specialconnection/SpecialTileConnection.java
+++ b/common/logisticspipes/proxy/specialconnection/SpecialTileConnection.java
@@ -1,6 +1,7 @@
 package logisticspipes.proxy.specialconnection;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import logisticspipes.interfaces.routing.ISpecialTileConnection;
@@ -17,7 +18,7 @@ public class SpecialTileConnection {
 		}
 	}
 	
-	public List<TileEntity> getConnectedPipes(TileEntity tile) {
+	public Collection<TileEntity> getConnectedPipes(TileEntity tile) {
 		for(ISpecialTileConnection connectionHandler:handler) {
 			if(connectionHandler.isType(tile)) {
 				return connectionHandler.getConnections(tile);
@@ -39,6 +40,7 @@ public class SpecialTileConnection {
 		for(ISpecialTileConnection connectionHandler:handler) {
 			if(connectionHandler.isType(tile)) {
 				connectionHandler.transmit(tile, arrivingItem);
+				break;
 			}
 		}
 	}

--- a/common/logisticspipes/routing/pathfinder/PathFinder.java
+++ b/common/logisticspipes/routing/pathfinder/PathFinder.java
@@ -10,6 +10,7 @@ package logisticspipes.routing.pathfinder;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -219,7 +220,7 @@ public class PathFinder {
 			int resistance = 0;
 			
 			if(root) {
-				List<TileEntity> list = SimpleServiceLocator.specialtileconnection.getConnectedPipes(tile);
+				Collection<TileEntity> list = SimpleServiceLocator.specialtileconnection.getConnectedPipes(tile);
 				if(!list.isEmpty()) {
 					for(TileEntity pipe:list) {
 						connections.add(new Pair<TileEntity, ForgeDirection>(pipe, direction));

--- a/common/logisticspipes/transport/PipeTransportLogistics.java
+++ b/common/logisticspipes/transport/PipeTransportLogistics.java
@@ -134,18 +134,20 @@ public class PipeTransportLogistics {
 			iterator.remove();
 		}
 	}
-	
-	public void injectItem(LPTravelingItemServer item, ForgeDirection inputOrientation) {
-		injectItem((LPTravelingItem)item, inputOrientation);
+
+	public int injectItem(LPTravelingItemServer item, ForgeDirection inputOrientation) {
+		return injectItem((LPTravelingItem)item, inputOrientation);
 	}
-	
-	public void injectItem(LPTravelingItem item, ForgeDirection inputOrientation) {
+
+	public int injectItem(LPTravelingItem item, ForgeDirection inputOrientation) {
 		if(item.isCorrupted())
 		// Safe guard - if for any reason the item is corrupted at this
 		// stage, avoid adding it to the pipe to avoid further exceptions.
-			return;
+			return 0;
 		getPipe().triggerDebug();
-		
+
+		int originalCount = item.getItemIdentifierStack().getStackSize();
+
 		item.input = inputOrientation;
 		
 		while(item.getPosition() >= 1.0F) {
@@ -156,7 +158,7 @@ public class PipeTransportLogistics {
 			readjustSpeed((LPTravelingItemServer)item);
 			item.output = resolveDestination((LPTravelingItemServer)item);
 			if(item.output == null) {
-				return; // don't do anything
+				return 0;
 			}
 			getPipe().debug.log("Injected Item: [" + item.input + ", " + item.output + "] (" + ((LPTravelingItemServer)item).getInfo());
 		} else {
@@ -168,10 +170,12 @@ public class PipeTransportLogistics {
 		if(MainProxy.isServer(container.getWorldObj()) && !getPipe().isOpaque()) {
 			sendItemPacket((LPTravelingItemServer)item);
 		}
+
+		return originalCount - item.getItemIdentifierStack().getStackSize();
 	}
 	
-	public void injectItem(IRoutedItem item, ForgeDirection inputOrientation) {
-		injectItem((LPTravelingItem)SimpleServiceLocator.routedItemHelper.getServerTravelingItem(item), inputOrientation);
+	public int injectItem(IRoutedItem item, ForgeDirection inputOrientation) {
+		return injectItem((LPTravelingItem)SimpleServiceLocator.routedItemHelper.getServerTravelingItem(item), inputOrientation);
 	}
 	
 	/**
@@ -216,10 +220,6 @@ public class PipeTransportLogistics {
 	
 	public ForgeDirection resolveDestination(LPTravelingItemServer data) {
 		
-		if(data != null && data.getItemIdentifierStack() != null) {
-			getPipe().relayedItem(data.getItemIdentifierStack().getStackSize());
-		}
-		
 		ForgeDirection blocked = null;
 		
 		if(data.getDestinationUUID() == null) {
@@ -227,11 +227,15 @@ public class PipeTransportLogistics {
 			ItemRoutingInformation result = getPipe().getQueuedForItemStack(stack);
 			if(result != null) {
 				data.setInformation(result);
-				data.getInfo().setItem(stack.clone());
+				data.getInfo().setItem(stack);
 				blocked = data.input.getOpposite();
 			}
 		}
-		
+
+		if(data.getItemIdentifierStack() != null) {
+			getPipe().relayedItem(data.getItemIdentifierStack().getStackSize());
+		}
+
 		ForgeDirection value;
 		if(this.getPipe().stillNeedReplace() || this.getPipe().initialInit()) {
 			data.setDoNotBuffer(false);

--- a/dummy/crazypants/enderio/machine/transceiver/Channel.java
+++ b/dummy/crazypants/enderio/machine/transceiver/Channel.java
@@ -1,0 +1,5 @@
+package crazypants.enderio.machine.transceiver;
+
+public class Channel {
+
+}

--- a/dummy/crazypants/enderio/machine/transceiver/ChannelType.java
+++ b/dummy/crazypants/enderio/machine/transceiver/ChannelType.java
@@ -1,0 +1,10 @@
+package crazypants.enderio.machine.transceiver;
+
+public enum ChannelType {
+    POWER,
+    ITEM,
+    FLUID,
+    RAIL;
+
+    public static final ChannelType[] VALUES = values();
+}

--- a/dummy/crazypants/enderio/machine/transceiver/ServerChannelRegister.java
+++ b/dummy/crazypants/enderio/machine/transceiver/ServerChannelRegister.java
@@ -1,0 +1,11 @@
+package crazypants.enderio.machine.transceiver;
+
+import java.util.Iterator;
+
+public class ServerChannelRegister {
+    public static ServerChannelRegister instance;
+
+    public Iterable<TileTransceiver> getIterator(Channel channel) {
+        return null;
+    }
+}

--- a/dummy/crazypants/enderio/machine/transceiver/TileTransceiver.java
+++ b/dummy/crazypants/enderio/machine/transceiver/TileTransceiver.java
@@ -1,0 +1,15 @@
+package crazypants.enderio.machine.transceiver;
+
+import net.minecraft.tileentity.TileEntity;
+
+import java.util.List;
+
+public class TileTransceiver extends TileEntity {
+    public List<Channel> getSendChannels(ChannelType type) {
+        return null;
+    }
+
+    public List<Channel> getRecieveChannels(ChannelType type) {
+        return null;
+    }
+}


### PR DESCRIPTION
Since EnderIO 2.1 old dimensional transceiver (also called HyperCube) is deprecated and replaced by the new system, this patch add support for new transceiver to LogisticsPipes.

Hook with stacks in CoreRoutedPipe required because new transceiver has a delay before pushing items in inventories (pipes) and if in this delay many stacks will be grouped in one bigger stack LP will send back new stack in system.
