### PR TITLE
Fix Storage Drawers support.

### DIFF
--- a/common/logisticspipes/proxy/specialinventoryhandler/StorageDrawersInventoryHandler.java
+++ b/common/logisticspipes/proxy/specialinventoryhandler/StorageDrawersInventoryHandler.java
@@ -128,7 +128,7 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 				continue;
 
 			IDrawer drawer = _drawer.getDrawer(i);
-			if(drawer != null && !drawer.isEmpty()) {
+			if(drawer != null && !drawer.isEmpty() && drawer.getStoredItemCount() > 0) {
 				result.add(ItemIdentifier.get(drawer.getStoredItemPrototype()));
 			}
 		}
@@ -145,11 +145,13 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 			IDrawer drawer = _drawer.getDrawer(i);
 			if(drawer != null && !drawer.isEmpty()) {
 				int count = drawer.getStoredItemCount();
-				ItemIdentifier ident = ItemIdentifier.get(drawer.getStoredItemCopy());
-				if(result.containsKey(ident)) {
-					result.put(ident, result.get(ident) + count);
-				} else {
-					result.put(ident, count);
+				if (count > 0) {
+					ItemIdentifier ident = ItemIdentifier.get(drawer.getStoredItemPrototype());
+					if (result.containsKey(ident)) {
+						result.put(ident, result.get(ident) + count);
+					} else {
+						result.put(ident, count);
+					}
 				}
 			}
 		}

--- a/common/logisticspipes/proxy/specialinventoryhandler/StorageDrawersInventoryHandler.java
+++ b/common/logisticspipes/proxy/specialinventoryhandler/StorageDrawersInventoryHandler.java
@@ -4,22 +4,22 @@ import java.util.HashMap;
 import java.util.Set;
 import java.util.TreeSet;
 
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
 import logisticspipes.utils.item.ItemIdentifier;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
-import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroupInteractive;
 
 public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 
-	private final IDrawerGroupInteractive _drawer;
+	private final IDrawerGroup _drawer;
 	private final boolean _hideOnePerStack;
 	private final boolean _hideOnePerType;
 
 	private StorageDrawersInventoryHandler(TileEntity tile, boolean hideOnePerStack, boolean hideOne, int cropStart, int cropEnd) {
-		_drawer = (IDrawerGroupInteractive) tile;
+		_drawer = (IDrawerGroup) tile;
 		_hideOnePerStack = hideOnePerStack;
 		_hideOnePerType = hideOne;
 	}
@@ -37,7 +37,7 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 
 	@Override
 	public boolean isType(TileEntity tile) {
-		return tile instanceof IDrawerGroupInteractive;
+		return tile instanceof IDrawerGroup;
 	}
 
 	@Override
@@ -50,39 +50,51 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 	public int itemCount(ItemIdentifier itemIdent) {
 		int count = 0;
 		boolean first = true;
-		for(int i=0; i < _drawer.getDrawerCount(); i++) {
+		for (int i = 0; i < _drawer.getDrawerCount(); i++) {
+			if (!_drawer.isDrawerEnabled(i))
+				continue;
+
 			IDrawer drawer = _drawer.getDrawer(i);
-			if(drawer != null && drawer.getStoredItemCopy() != null) {
-				if(ItemIdentifier.get(drawer.getStoredItemCopy()).equals(itemIdent)) {
-					count += drawer.getStoredItemCount() - (_hideOnePerStack ? 1:0) - (_hideOnePerType && first ? 1:0);
-					first = false;
-				}
+			if (drawer == null)
+				continue;
+
+			if (!drawer.isEmpty() && ItemIdentifier.get(drawer.getStoredItemPrototype()).equals(itemIdent)) {
+				count += drawer.getStoredItemCount() - ((_hideOnePerStack || (_hideOnePerType && first)) ? 1 : 0);
+				first = false;
 			}
 		}
+
 		return count;
 	}
 
 	@Override
 	public ItemStack getMultipleItems(ItemIdentifier itemIdent, int count) {
 		ItemStack stack = null;
-		for(int i=0; i < _drawer.getDrawerCount(); i++) {
+		for (int i = 0; i < _drawer.getDrawerCount(); i++) {
+			if (!_drawer.isDrawerEnabled(i))
+				continue;
+
 			IDrawer drawer = _drawer.getDrawer(i);
-			if(drawer != null && drawer.getStoredItemCopy() != null) {
-				if(ItemIdentifier.get(drawer.getStoredItemCopy()).equals(itemIdent)) {
-					if(stack == null) {
-						stack = _drawer.takeItemsFromSlot(i, count);
-						count -= stack.stackSize;
-						if(count <= 0) break;
-					} else {
-						ItemStack toAdd = _drawer.takeItemsFromSlot(i, count);
-						if(!ItemIdentifier.get(toAdd).equals(itemIdent)) throw new UnsupportedOperationException();
-						stack.stackSize += toAdd.stackSize;
-						count -= toAdd.stackSize;
-						if(count <= 0) break;
-					}
+			if (drawer == null || drawer.isEmpty())
+				continue;
+
+			if (ItemIdentifier.get(drawer.getStoredItemPrototype()).equals(itemIdent)) {
+				if (stack == null) {
+					stack = drawer.getStoredItemCopy();
+					stack.stackSize = 0;
 				}
+
+				int avail = Math.min(count, drawer.getStoredItemCount());
+				drawer.setStoredItemCount(drawer.getStoredItemCount() - avail);
+
+				stack.stackSize += avail;
+				count -= avail;
+
+				if (count <= 0)
+					break;
 			}
 		}
+
 		return stack;
 	}
 
@@ -90,9 +102,12 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 	public Set<ItemIdentifier> getItems() {
 		Set<ItemIdentifier> result = new TreeSet<ItemIdentifier>();
 		for(int i=0; i < _drawer.getDrawerCount(); i++) {
+			if (!_drawer.isDrawerEnabled(i))
+				continue;
+
 			IDrawer drawer = _drawer.getDrawer(i);
-			if(drawer != null && drawer.getStoredItemCopy() != null) {
-				result.add(ItemIdentifier.get(drawer.getStoredItemCopy()));
+			if(drawer != null && !drawer.isEmpty()) {
+				result.add(ItemIdentifier.get(drawer.getStoredItemPrototype()));
 			}
 		}
 		return result;
@@ -102,8 +117,11 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 	public HashMap<ItemIdentifier, Integer> getItemsAndCount() {
 		HashMap<ItemIdentifier, Integer> result = new HashMap<ItemIdentifier, Integer>();
 		for(int i=0; i < _drawer.getDrawerCount(); i++) {
+			if (!_drawer.isDrawerEnabled(i))
+				continue;
+
 			IDrawer drawer = _drawer.getDrawer(i);
-			if(drawer != null && drawer.getStoredItemCopy() != null) {
+			if(drawer != null && !drawer.isEmpty()) {
 				int count = drawer.getStoredItemCount();
 				ItemIdentifier ident = ItemIdentifier.get(drawer.getStoredItemCopy());
 				if(result.containsKey(ident)) {
@@ -124,8 +142,11 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 	@Override
 	public boolean containsItem(ItemIdentifier itemIdent) {
 		for(int i=0; i < _drawer.getDrawerCount(); i++) {
+			if (!_drawer.isDrawerEnabled(i))
+				continue;
+
 			IDrawer drawer = _drawer.getDrawer(i);
-			if(drawer != null && drawer.getStoredItemCopy() != null) {
+			if(drawer != null && !drawer.isEmpty()) {
 				if(drawer.canItemBeStored(itemIdent.makeNormalStack(1))) {
 					return true;
 				}
@@ -137,9 +158,12 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 	@Override
 	public boolean containsUndamagedItem(ItemIdentifier itemIdent) {
 		for(int i=0; i < _drawer.getDrawerCount(); i++) {
+			if (!_drawer.isDrawerEnabled(i))
+				continue;
+
 			IDrawer drawer = _drawer.getDrawer(i);
-			if(drawer != null && drawer.getStoredItemCopy() != null) {
-				if(ItemIdentifier.get(drawer.getStoredItemCopy()).getUndamaged().equals(itemIdent)) {
+			if(drawer != null && !drawer.isEmpty()) {
+				if(ItemIdentifier.get(drawer.getStoredItemPrototype()).getUndamaged().equals(itemIdent)) {
 					return true;
 				}
 			}
@@ -155,36 +179,60 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 	@Override
 	public int roomForItem(ItemIdentifier itemIdent, int count) {
 		int room = 0;
-		for(int i=0; i < _drawer.getDrawerCount(); i++) {
+		for (int i = 0; i < _drawer.getDrawerCount(); i++) {
+			if (!_drawer.isDrawerEnabled(i))
+				continue;
+
 			IDrawer drawer = _drawer.getDrawer(i);
-			if(drawer != null && drawer.getStoredItemCopy() == null) {
-				count += drawer.getMaxCapacity();
-			} else if(drawer != null && drawer.canItemBeStored(itemIdent.makeNormalStack(1))) {
-				count += drawer.getRemainingCapacity();
+			if (drawer == null)
+				continue;
+
+			ItemStack protoStack = itemIdent.makeNormalStack(1);
+			if (drawer.canItemBeStored(protoStack)) {
+				if (drawer.isEmpty()) {
+					room += drawer.getMaxCapacity(protoStack);
+				}
+				else {
+					room += drawer.getRemainingCapacity();
+				}
 			}
 		}
-		if(count != 0) {
-			return Math.min(room, count);
-		} else {
-			return room;
-		}
+
+		return room;
 	}
 
 	@Override
 	public ItemStack add(ItemStack stack, ForgeDirection from, boolean doAdd) {
 		ItemStack st = stack.copy();
 		st.stackSize = 0;
-		
-		for(int i=0; i < _drawer.getDrawerCount(); i++) {
+
+		for (int i = 0; i < _drawer.getDrawerCount(); i++) {
+			if (!_drawer.isDrawerEnabled(i))
+				continue;
+
 			IDrawer drawer = _drawer.getDrawer(i);
-			if(drawer != null) {
-				if(drawer.canItemBeStored(stack)) {
-					int used = _drawer.putItemsIntoSlot(i, stack.copy(), stack.stackSize);
-					stack.stackSize -= used;
-					st.stackSize += used;
+			if (drawer == null)
+				continue;
+
+			if (drawer.canItemBeStored(stack)) {
+				int avail = 0;
+				if (drawer.isEmpty()) {
+					avail = Math.min(stack.stackSize, drawer.getMaxCapacity(stack));
+					drawer.setStoredItem(stack.copy(), avail);
 				}
+				else {
+					avail = Math.min(stack.stackSize, drawer.getRemainingCapacity());
+					drawer.setStoredItemCount(drawer.getStoredItemCount() + avail);
+				}
+
+				stack.stackSize -= avail;
+				st.stackSize += avail;
+
+				if (stack.stackSize <= 0)
+					break;
 			}
 		}
+
 		return st;
 	}
 
@@ -200,11 +248,21 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 
 	@Override
 	public ItemStack getStackInSlot(int i) {
+		if (!_drawer.isDrawerEnabled(i))
+			return null;
+
 		return _drawer.getDrawer(i) != null ? _drawer.getDrawer(i).getStoredItemCopy() : null;
 	}
 
 	@Override
 	public ItemStack decrStackSize(int i, int j) {
-		return _drawer.takeItemsFromSlot(i, j);
+		if (!_drawer.isDrawerEnabled(i))
+			return null;
+
+		IDrawer drawer = _drawer.getDrawer(i);
+		if (drawer == null)
+			return null;
+
+		return getMultipleItems(ItemIdentifier.get(drawer.getStoredItemPrototype()), j);
 	}
 }

--- a/dummy/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawer.java
+++ b/dummy/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawer.java
@@ -45,6 +45,13 @@ public interface IDrawer
     int getMaxCapacity ();
 
     /**
+     * Gets the maximum number of items that could be stored in this drawer if it held the given item.
+     *
+     * @param itemPrototype The item type to query.
+     */
+    int getMaxCapacity (ItemStack itemPrototype);
+
+    /**
      * Gets the number of items that could still be added to this drawer before it is full.
      */
     int getRemainingCapacity ();
@@ -80,6 +87,21 @@ public interface IDrawer
      * A drawer set with an item type and 0 count is not considered empty.
      */
     boolean isEmpty ();
+
+    /**
+     * Gets auxiliary data that has been associated with this drawer.
+     *
+     * @param key The key used to identify the data.
+     * @return An opaque object that was previously stored.
+     */
+    Object getExtendedData (String key);
+
+    /**
+     * Stores auxiliary data with this drawer, mainly for use in integration.
+     * @param key The key to identify the data with.
+     * @param data The data to store.
+     */
+    void setExtendedData (String key, Object data);
 
     void writeToNBT (NBTTagCompound tag);
 

--- a/dummy/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawerGroup.java
+++ b/dummy/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawerGroup.java
@@ -1,7 +1,5 @@
 package com.jaquadro.minecraft.storagedrawers.api.storage;
 
-//import com.jaquadro.minecraft.storagedrawers.api.inventory.IDrawerInventory;
-
 public interface IDrawerGroup
 {
     /**


### PR DESCRIPTION
First, thank you @davboecki for writing the initial integration for this.  I completely failed to get around to it.

I ran off and did some testing after I got notified of the closed issue, but found it wasn't working.  I've updated the implementation with what I think is correct.

My main test setup has been a drawer, supplier, pipe, provider, and chest, testing the block as both a supplier and provider. As far as I can tell that's all working correctly now, but there's a lot to LP that I don't currently understand, so I can't say that my testing was thorough.

I published 2 new builds of Storage Drawers since this support was initially merged, adding a necessary API entry and fixing a dupe bug that would have emerged with the LP support.
