### PR TITLE
Fix fluid crash in newest forge

### DIFF
--- a/common/logisticspipes/network/packets/pipe/PipeFluidUpdate.java
+++ b/common/logisticspipes/network/packets/pipe/PipeFluidUpdate.java
@@ -88,7 +88,7 @@ public class PipeFluidUpdate extends CoordinatesPacket {
 		try {
 			for (ForgeDirection dir : ForgeDirection.values()) {
 				if (renderCache[dir.ordinal()] == null) {
-					renderCache[dir.ordinal()] = new FluidStack(0, 0);
+					continue;
 				}
 				
 				if (delta.get(dir.ordinal() * 3 + 0)) {


### PR DESCRIPTION
May do something for RS485/LogisticsPipes#662

I know you don't care for the newest forge, but this fixes the crash that happens when placing fluid-based logistics pipes.
