### PR TITLE
Fix missed recipe(s) for Crafting Cleanup Upgrade (works)

### DIFF
--- a/common/logisticspipes/recipes/RecipeManager.java
+++ b/common/logisticspipes/recipes/RecipeManager.java
@@ -9,7 +9,6 @@ import logisticspipes.items.ItemUpgrade;
 import logisticspipes.items.RemoteOrderer;
 import logisticspipes.modules.abstractmodules.LogisticsModule;
 import logisticspipes.proxy.interfaces.ICraftingParts;
-
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.InventoryCrafting;
@@ -17,7 +16,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.nbt.NBTTagCompound;
-
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
 //@formatter:off
@@ -1010,6 +1008,47 @@ public class RecipeManager {
 				Character.valueOf('b'), "dyeWhite",
 			});
 
+			/*
+			 * added by Chaos234
+			 */
+			RecipeManager.craftingManager.addRecipe(new ItemStack(LogisticsPipes.UpgradeItem, 1, ItemUpgrade.CRAFTING_CLEANUP), CraftingDependency.Upgrades, new Object[] {
+				false,
+				"rRr",
+				"PCP",
+				"rBr",
+				Character.valueOf('r'), Items.redstone,
+				Character.valueOf('R'), "dyeRed",
+				Character.valueOf('P'), Items.paper,
+				Character.valueOf('C'), parts.getChipTear1(),
+				Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.EXTRACTOR_MK3),
+			});
+			
+			RecipeManager.craftingManager.addRecipe(new ItemStack(LogisticsPipes.UpgradeItem, 1, ItemUpgrade.CRAFTING_CLEANUP), CraftingDependency.Upgrades, new Object[] {
+				false,
+				"rRr",
+				"PCP",
+				"rBr",
+				Character.valueOf('r'), Items.redstone,
+				Character.valueOf('R'), "dyeRed",
+				Character.valueOf('P'), Items.paper,
+				Character.valueOf('C'), parts.getChipTear2(),
+				Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.EXTRACTOR_MK2),
+			});
+
+			RecipeManager.craftingManager.addRecipe(new ItemStack(LogisticsPipes.UpgradeItem, 1, ItemUpgrade.CRAFTING_CLEANUP), CraftingDependency.Upgrades, new Object[] {
+				false,
+				"rRr",
+				"PCP",
+				"rBr",
+				Character.valueOf('r'), Items.redstone,
+				Character.valueOf('R'), "dyeRed",
+				Character.valueOf('P'), Items.paper,
+				Character.valueOf('C'), parts.getChipTear3(),
+				Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.EXTRACTOR),
+			});
+			
+			/* add end */
+			
 			RecipeManager.craftingManager.addRecipe(new ItemStack(LogisticsPipes.LogisticsFluidBasicPipe, 1), CraftingDependency.Basic_Liquid, new Object[] {
 				"w",
 				"B",
@@ -1831,7 +1870,48 @@ public class RecipeManager {
 				Character.valueOf('b'), "dyeWhite",
 				Character.valueOf('I'), Items.iron_ingot
 			});
+			
+			/*
+			 * added by Chaos234
+			 */
+			RecipeManager.craftingManager.addRecipe(new ItemStack(LogisticsPipes.UpgradeItem, 1, ItemUpgrade.CRAFTING_CLEANUP), CraftingDependency.Upgrades, new Object[] {
+				false,
+				"rRr",
+				"PCP",
+				"rBr",
+				Character.valueOf('r'), Items.redstone,
+				Character.valueOf('R'), "dyeRed",
+				Character.valueOf('P'), Items.paper,
+				Character.valueOf('C'), parts.getChipTear1(),
+				Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.EXTRACTOR_MK3),
+			});
+			
+			RecipeManager.craftingManager.addRecipe(new ItemStack(LogisticsPipes.UpgradeItem, 1, ItemUpgrade.CRAFTING_CLEANUP), CraftingDependency.Upgrades, new Object[] {
+				false,
+				"rRr",
+				"PCP",
+				"rBr",
+				Character.valueOf('r'), Items.redstone,
+				Character.valueOf('R'), "dyeRed",
+				Character.valueOf('P'), Items.paper,
+				Character.valueOf('C'), parts.getChipTear2(),
+				Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.EXTRACTOR_MK2),
+			});
 
+			RecipeManager.craftingManager.addRecipe(new ItemStack(LogisticsPipes.UpgradeItem, 1, ItemUpgrade.CRAFTING_CLEANUP), CraftingDependency.Upgrades, new Object[] {
+				false,
+				"rRr",
+				"PCP",
+				"rBr",
+				Character.valueOf('r'), Items.redstone,
+				Character.valueOf('R'), "dyeRed",
+				Character.valueOf('P'), Items.paper,
+				Character.valueOf('C'), parts.getChipTear3(),
+				Character.valueOf('B'), new ItemStack(LogisticsPipes.ModuleItem, 1, ItemModule.EXTRACTOR),
+			});
+			
+			/* add end */
+			
 			RecipeManager.craftingManager.addRecipe(new ItemStack(LogisticsPipes.LogisticsFluidBasicPipe, 1), CraftingDependency.Basic_Liquid, new Object[] {
 				" l ",
 				"lPl",

--- a/common/logisticspipes/recipes/RecipeManager.java
+++ b/common/logisticspipes/recipes/RecipeManager.java
@@ -1009,7 +1009,11 @@ public class RecipeManager {
 			});
 
 			/*
+<<<<<<< HEAD
+			 * added by Chaos234 - Date: 20150620
+=======
 			 * added by Chaos234
+>>>>>>> 8591e71125387113e59bc334d477514b2221a828
 			 */
 			RecipeManager.craftingManager.addRecipe(new ItemStack(LogisticsPipes.UpgradeItem, 1, ItemUpgrade.CRAFTING_CLEANUP), CraftingDependency.Upgrades, new Object[] {
 				false,
@@ -1872,7 +1876,11 @@ public class RecipeManager {
 			});
 			
 			/*
+<<<<<<< HEAD
+			 * added by Chaos234  - Date: 20150620
+=======
 			 * added by Chaos234
+>>>>>>> 8591e71125387113e59bc334d477514b2221a828
 			 */
 			RecipeManager.craftingManager.addRecipe(new ItemStack(LogisticsPipes.UpgradeItem, 1, ItemUpgrade.CRAFTING_CLEANUP), CraftingDependency.Upgrades, new Object[] {
 				false,


### PR DESCRIPTION
For my own issue #710 I've added in the RecipeManager.java three different recipes for the Crafting Celanup Upgrade because there wasn't any recipe for that one.

I hope the recipes are not to strong and also you accept them (will be fine).

I tested it with the current 1.5.0 FTB Infinity by changing the old version (0.8.3.118) to the builded version 0.9.1.local and there was no error with the crafting recipes nor with the functionality of the upgrade.

OT: I like the new designe of LP :+1: 
