### PR TITLE
Update StorageDrawers API to fix dev environment

### DIFF
--- a/dummy/com/jaquadro/minecraft/storagedrawers/api/inventory/IDrawerInventory.java
+++ b/dummy/com/jaquadro/minecraft/storagedrawers/api/inventory/IDrawerInventory.java
@@ -1,0 +1,35 @@
+package com.jaquadro.minecraft.storagedrawers.api.inventory;
+
+import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.item.ItemStack;
+
+public interface IDrawerInventory extends ISidedInventory
+{
+    /**
+     * Gets a drawer's group slot index from an IInventory slot index.
+     *
+     * @param inventorySlot An IInventory slot index returned from getInventorySlot.
+     */
+    int getDrawerSlot (int inventorySlot);
+
+    /**
+     * Gets an IInventory slot index suitable for operations for the given type.
+     *
+     * @param drawerSlot The index of the drawer within its group.
+     * @param type The type of IInventory slot to return an index for.
+     */
+    //int getInventorySlot (int drawerSlot, SlotType type);
+
+    /**
+     * Gets the type associated with a given IInventory slot index.
+     *
+     * @param inventorySlot An IInventory slot index returned from getInventorySlot.
+     */
+    //SlotType getInventorySlotType (int inventorySlot);
+
+    boolean canInsertItem (int slot, ItemStack stack);
+
+    boolean canExtractItem (int slot, ItemStack stack);
+
+    boolean syncInventoryIfNeeded ();
+}

--- a/dummy/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawerGroup.java
+++ b/dummy/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawerGroup.java
@@ -1,5 +1,7 @@
 package com.jaquadro.minecraft.storagedrawers.api.storage;
 
+import com.jaquadro.minecraft.storagedrawers.api.inventory.IDrawerInventory;
+
 public interface IDrawerGroup
 {
     /**
@@ -17,7 +19,7 @@ public interface IDrawerGroup
      */
     boolean isDrawerEnabled (int slot);
 
-    //IDrawerInventory getDrawerInventory ();
+    IDrawerInventory getDrawerInventory ();
 
     boolean markDirtyIfNeeded ();
 }


### PR DESCRIPTION
The StorageDrawers(SD) API has changed a bit from the version we have in LP.
This causes the dev environment to crash upon ticking of a SD drawer controller.

This change is not needed to fix any actual bugs in LP, as the compiled jar works fine, but this change prevents the Dev environment from crashing.

I'm not 100% sure if there is a cleaner way to do this, but this change definitely fixes the problem of the dev environment crashing when StorageDrawers is loaded and used.
