### PR TITLE
Various Fixes for Beta-Recipe-Item Issues

### DIFF
--- a/common/logisticspipes/items/ItemPipeComponents.java
+++ b/common/logisticspipes/items/ItemPipeComponents.java
@@ -32,7 +32,8 @@ public class ItemPipeComponents extends LogisticsItem {
 	private IIcon[] _icons;
 
 	public ItemPipeComponents() {
-		setHasSubtypes(true);
+		if(Configs.ENABLE_BETA_RECIPES)
+			setHasSubtypes(true);
 	}
 
 	@Override


### PR DESCRIPTION
Fixed Beta-Items appearing if Disabled
Fixed Beta-Items having 2x the amount of Subtypes when disabled
Note: A single, Untextured Beta-Item is present in NEI, this is inavoidable
