### PR TITLE
Improve Storage Drawers Integration- Polymorphic

### DIFF
--- a/common/logisticspipes/pipes/PipeItemsInvSysConnector.java
+++ b/common/logisticspipes/pipes/PipeItemsInvSysConnector.java
@@ -140,6 +140,9 @@ public class PipeItemsInvSysConnector extends CoreRoutedPipe implements IDirectR
 				amounts = inv.getItemsAndCount();
 			}
 			for (ItemIdentifier ident : items) {
+				if (!amounts.containsKey(ident)) {
+					continue;
+				}
 				int itemAmount = amounts.get(ident);
 				List<ItemRoutingInformation> needs = itemsOnRoute.get(ident);
 				for (Iterator<ItemRoutingInformation> iterator = needs.iterator(); iterator.hasNext();) {

--- a/common/logisticspipes/proxy/specialinventoryhandler/StorageDrawersInventoryHandler.java
+++ b/common/logisticspipes/proxy/specialinventoryhandler/StorageDrawersInventoryHandler.java
@@ -136,7 +136,7 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 			}
 
 			IDrawer drawer = _drawer.getDrawer(i);
-			if (drawer != null && !drawer.isEmpty() && drawer.getStoredItemCount() > 0) {
+			if (drawer != null && !drawer.isEmpty()) {
 				result.add(ItemIdentifier.get(drawer.getStoredItemPrototype()));
 			}
 		}


### PR DESCRIPTION
This will make Logistics Pipes consider drawers that are "empty, but locked to that item" as a valid destination for said item.
With this, a single polymorphic item sink will work for a bank of drawers, even when some of them have become empty, but were locked to remember that item.

Fixes everything that I could confirm as still an issue in #808
