### PR TITLE
Possible fix for RS485/LogisticsPipes/issues/802

### DIFF
--- a/common/logisticspipes/proxy/specialinventoryhandler/StorageDrawersInventoryHandler.java
+++ b/common/logisticspipes/proxy/specialinventoryhandler/StorageDrawersInventoryHandler.java
@@ -316,10 +316,14 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 			return null;
 		}
 
+		ItemStack stack = drawer.getStoredItemCopy();
+		if (stack == null) {
+			return null;
+		}
+
 		int avail = Math.min(j, drawer.getStoredItemCount());
 		drawer.setStoredItemCount(drawer.getStoredItemCount() - avail);
 
-		ItemStack stack = drawer.getStoredItemCopy();
 		stack.stackSize = avail;
 
 		return stack;


### PR DESCRIPTION
This should fix https://github.com/RS485/LogisticsPipes/issues/802#issuecomment-161108538

(Still waiting Fitheach to reply confirming it wasn't a fluke, but I'm pretty sure this is it.)

And as decrStackSize() can already return null, shoudn't create any new issues.
