### PR TITLE
#906: LP and FORESTRY

### DIFF
--- a/common/logisticspipes/proxy/forestry/ForestryProgressProvider.java
+++ b/common/logisticspipes/proxy/forestry/ForestryProgressProvider.java
@@ -6,7 +6,7 @@ import logisticspipes.proxy.interfaces.IGenericProgressProvider;
 
 import net.minecraft.tileentity.TileEntity;
 
-import forestry.core.gadgets.TilePowered;
+import forestry.core.tiles.TilePowered;
 
 public class ForestryProgressProvider implements IGenericProgressProvider {
 

--- a/dummy/forestry/core/tiles/TilePowered.java
+++ b/dummy/forestry/core/tiles/TilePowered.java
@@ -1,4 +1,4 @@
-package forestry.core.gadgets;
+package forestry.core.tiles;
 
 import net.minecraft.tileentity.TileEntity;
 


### PR DESCRIPTION
Updating missed references to the TilePowered class, which also was
moved to a different package for Forestry 4.0
