### PR TITLE
Update Storage Drawers integration to use ISmartGroup when available

### DIFF
--- a/common/logisticspipes/proxy/specialinventoryhandler/StorageDrawersInventoryHandler.java
+++ b/common/logisticspipes/proxy/specialinventoryhandler/StorageDrawersInventoryHandler.java
@@ -52,7 +52,7 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 			ModContainer mod = modList.get(i);
 			if (mod.getModId().equals("StorageDrawers")) {
 				try {
-					VersionRange validVersions = VersionRange.createFromVersionSpec("[1.3.4,)");
+					VersionRange validVersions = VersionRange.createFromVersionSpec("[1.7.8,)");
 					ArtifactVersion version = new DefaultArtifactVersion(mod.getVersion());
 					return validVersions.containsVersion(version);
 				} catch (InvalidVersionSpecificationException e) {

--- a/common/logisticspipes/proxy/specialinventoryhandler/StorageDrawersInventoryHandler.java
+++ b/common/logisticspipes/proxy/specialinventoryhandler/StorageDrawersInventoryHandler.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import com.jaquadro.minecraft.storagedrawers.api.storage.ISmartGroup;
 import logisticspipes.utils.item.ItemIdentifier;
 
 import net.minecraft.item.ItemStack;
@@ -26,17 +27,20 @@ import com.jaquadro.minecraft.storagedrawers.api.storage.attribute.IVoidable;
 public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 
 	private final IDrawerGroup _drawer;
+	private final ISmartGroup _smartGroup;
 	private final boolean _hideOnePerStack;
 	private final boolean _hideOnePerType;
 
 	private StorageDrawersInventoryHandler(TileEntity tile, boolean hideOnePerStack, boolean hideOne, int cropStart, int cropEnd) {
 		_drawer = (IDrawerGroup) tile;
+		_smartGroup = (_drawer instanceof ISmartGroup) ? (ISmartGroup) _drawer : null;
 		_hideOnePerStack = hideOnePerStack;
 		_hideOnePerType = hideOne;
 	}
 
 	public StorageDrawersInventoryHandler() {
 		_drawer = null;
+		_smartGroup = null;
 		_hideOnePerStack = false;
 		_hideOnePerType = false;
 	}
@@ -74,6 +78,22 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 	public int itemCount(ItemIdentifier itemIdent) {
 		int count = 0;
 		boolean first = true;
+
+		if (_smartGroup != null) {
+			ItemStack protoStack = itemIdent.makeNormalStack(1);
+			for (int slot : _smartGroup.enumerateDrawersForExtraction(protoStack, true)) {
+				IDrawer drawer = _drawer.getDrawer(slot);
+				if (drawer.isEmpty() || !ItemIdentifier.get(drawer.getStoredItemPrototype()).equals(itemIdent)) {
+					continue;
+				}
+
+				count += drawer.getStoredItemCount() - ((_hideOnePerStack || (_hideOnePerType && first)) ? 1 : 0);
+				first = false;
+			}
+
+			return count;
+		}
+
 		for (int i = 0; i < _drawer.getDrawerCount(); i++) {
 			if (!_drawer.isDrawerEnabled(i)) {
 				continue;
@@ -96,6 +116,34 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 	@Override
 	public ItemStack getMultipleItems(ItemIdentifier itemIdent, int count) {
 		ItemStack stack = null;
+
+		if (_smartGroup != null) {
+			ItemStack protoStack = itemIdent.makeNormalStack(1);
+			for (int slot : _smartGroup.enumerateDrawersForExtraction(protoStack, true)) {
+				IDrawer drawer = _drawer.getDrawer(slot);
+				if (drawer.isEmpty() || !ItemIdentifier.get(drawer.getStoredItemPrototype()).equals(itemIdent)) {
+					continue;
+				}
+
+				if (stack == null) {
+					stack = drawer.getStoredItemCopy();
+					stack.stackSize = 0;
+				}
+
+				int avail = Math.min(count, drawer.getStoredItemCount());
+				drawer.setStoredItemCount(drawer.getStoredItemCount() - avail);
+
+				stack.stackSize += avail;
+				count -= avail;
+
+				if (count <= 0) {
+					break;
+				}
+			}
+
+			return stack;
+		}
+
 		for (int i = 0; i < _drawer.getDrawerCount(); i++) {
 			if (!_drawer.isDrawerEnabled(i)) {
 				continue;
@@ -174,6 +222,17 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 
 	@Override
 	public boolean containsItem(ItemIdentifier itemIdent) {
+		ItemStack stack = itemIdent.makeNormalStack(1);
+		if (_smartGroup != null) {
+			for (int slot : _smartGroup.enumerateDrawersForExtraction(stack, true)) {
+				IDrawer drawer = _drawer.getDrawer(slot);
+				if (!drawer.isEmpty()) {
+					return true;
+				}
+			}
+			return false;
+		}
+
 		for (int i = 0; i < _drawer.getDrawerCount(); i++) {
 			if (!_drawer.isDrawerEnabled(i)) {
 				continue;
@@ -181,7 +240,7 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 
 			IDrawer drawer = _drawer.getDrawer(i);
 			if (drawer != null && !drawer.isEmpty()) {
-				if (drawer.canItemBeStored(itemIdent.makeNormalStack(1))) {
+				if (drawer.canItemBeStored(stack)) {
 					return true;
 				}
 			}
@@ -191,6 +250,17 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 
 	@Override
 	public boolean containsUndamagedItem(ItemIdentifier itemIdent) {
+		if (_smartGroup != null) {
+			ItemStack stack = itemIdent.makeNormalStack(1);
+			for (int slot : _smartGroup.enumerateDrawersForExtraction(stack, true)) {
+				IDrawer drawer = _drawer.getDrawer(slot);
+				if (!drawer.isEmpty() && ItemIdentifier.get(drawer.getStoredItemPrototype()).getUndamaged().equals(itemIdent)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
 		for (int i = 0; i < _drawer.getDrawerCount(); i++) {
 			if (!_drawer.isDrawerEnabled(i)) {
 				continue;
@@ -214,6 +284,29 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 	@Override
 	public int roomForItem(ItemIdentifier itemIdent, int count) {
 		int room = 0;
+		ItemStack protoStack = itemIdent.makeNormalStack(1);
+
+		if (_smartGroup != null) {
+			for (int slot : _smartGroup.enumerateDrawersForInsertion(protoStack, false)) {
+				IDrawer drawer = _drawer.getDrawer(slot);
+				if (!drawer.isEmpty()) {
+					if (drawer instanceof IVoidable && ((IVoidable) drawer).isVoid()) {
+						room += drawer.getMaxCapacity();
+					} else {
+						room += drawer.getRemainingCapacity();
+					}
+				} else {
+					room += drawer.getMaxCapacity(protoStack);
+				}
+
+				if (count != 0 && room >= count) {
+					return count;
+				}
+			}
+
+			return room;
+		}
+
 		for (int i = 0; i < _drawer.getDrawerCount(); i++) {
 			if (!_drawer.isDrawerEnabled(i)) {
 				continue;
@@ -224,7 +317,7 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 				continue;
 			}
 
-			ItemStack protoStack = itemIdent.makeNormalStack(1);
+
 			if (drawer.canItemBeStored(protoStack)) {
 				if (drawer.isEmpty()) {
 					room += drawer.getMaxCapacity(protoStack);
@@ -250,6 +343,37 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 		ItemStack st = stack.copy();
 		st.stackSize = 0;
 
+		if (_smartGroup != null) {
+			for (int slot : _smartGroup.enumerateDrawersForInsertion(stack, false)) {
+				IDrawer drawer = _drawer.getDrawer(slot);
+				int avail = 0;
+				if (!drawer.isEmpty()) {
+					avail = Math.min(stack.stackSize, drawer.getRemainingCapacity());
+					if (doAdd) {
+						drawer.setStoredItemCount(drawer.getStoredItemCount() + avail);
+					}
+				} else {
+					avail = Math.min(stack.stackSize, drawer.getMaxCapacity(stack));
+					if (doAdd) {
+						drawer.setStoredItem(stack, avail);
+					}
+				}
+
+				if (drawer instanceof IVoidable && ((IVoidable) drawer).isVoid()) {
+					return stack;
+				}
+
+				stack.stackSize -= avail;
+				st.stackSize += avail;
+
+				if (stack.stackSize <= 0) {
+					break;
+				}
+			}
+
+			return st;
+		}
+
 		for (int i = 0; i < _drawer.getDrawerCount(); i++) {
 			if (!_drawer.isDrawerEnabled(i)) {
 				continue;
@@ -264,10 +388,14 @@ public class StorageDrawersInventoryHandler extends SpecialInventoryHandler {
 				int avail = 0;
 				if (drawer.isEmpty()) {
 					avail = Math.min(stack.stackSize, drawer.getMaxCapacity(stack));
-					drawer.setStoredItem(stack.copy(), avail);
+					if (doAdd) {
+						drawer.setStoredItem(stack.copy(), avail);
+					}
 				} else {
 					avail = Math.min(stack.stackSize, drawer.getRemainingCapacity());
-					drawer.setStoredItemCount(drawer.getStoredItemCount() + avail);
+					if (doAdd) {
+						drawer.setStoredItemCount(drawer.getStoredItemCount() + avail);
+					}
 				}
 
 				if (drawer instanceof IVoidable && ((IVoidable) drawer).isVoid()) {

--- a/dummy/com/jaquadro/minecraft/storagedrawers/api/storage/IPriorityGroup.java
+++ b/dummy/com/jaquadro/minecraft/storagedrawers/api/storage/IPriorityGroup.java
@@ -1,0 +1,10 @@
+package com.jaquadro.minecraft.storagedrawers.api.storage;
+
+
+public interface IPriorityGroup
+{
+    /**
+     * Gets the list of available drawer slots in priority order.
+     */
+    int[] getAccessibleDrawerSlots ();
+}

--- a/dummy/com/jaquadro/minecraft/storagedrawers/api/storage/ISmartGroup.java
+++ b/dummy/com/jaquadro/minecraft/storagedrawers/api/storage/ISmartGroup.java
@@ -1,0 +1,18 @@
+package com.jaquadro.minecraft.storagedrawers.api.storage;
+
+import net.minecraft.item.ItemStack;
+
+public interface ISmartGroup
+{
+    /**
+     * Gets a lazy enumeration of all slots that will accept at least one item of the given stack, ordered by
+     * insertion preference.
+     */
+    Iterable<Integer> enumerateDrawersForInsertion (ItemStack stack, boolean strict);
+
+    /**
+     * Gets a lazy enumeration of all slots that will provide at least one item of the given stack, ordered by
+     * extraction preference.
+     */
+    Iterable<Integer> enumerateDrawersForExtraction (ItemStack stack, boolean strict);
+}

--- a/dummy/com/jaquadro/minecraft/storagedrawers/api/storage/attribute/ILockable.java
+++ b/dummy/com/jaquadro/minecraft/storagedrawers/api/storage/attribute/ILockable.java
@@ -1,0 +1,21 @@
+package com.jaquadro.minecraft.storagedrawers.api.storage.attribute;
+
+public interface ILockable
+{
+    /**
+     * Gets whether or not a drawer or group is locked for the given lock attribute.
+     */
+    boolean isLocked (LockAttribute attr);
+
+    /**
+     * Gets whether or not the lock state can be changed for the given lock attribute.
+     * If this method returns false, isLocked may still return true.
+     */
+    boolean canLock (LockAttribute attr);
+
+    /**
+     * Sets the lock state of a drawer or group for the given lock attribute.
+     * If canLock returns false, this is a no-op.
+     */
+    void setLocked (LockAttribute attr, boolean isLocked);
+}

--- a/dummy/com/jaquadro/minecraft/storagedrawers/api/storage/attribute/LockAttribute.java
+++ b/dummy/com/jaquadro/minecraft/storagedrawers/api/storage/attribute/LockAttribute.java
@@ -1,0 +1,37 @@
+package com.jaquadro.minecraft.storagedrawers.api.storage.attribute;
+
+import java.util.EnumSet;
+
+public enum LockAttribute
+{
+    LOCK_POPULATED,
+    LOCK_EMPTY;
+
+    public int getFlagValue () {
+        return 1 << ordinal();
+    }
+
+    public static int getBitfield (EnumSet<LockAttribute> attributes) {
+        int value = 0;
+        if (attributes == null)
+            return value;
+
+        for (LockAttribute attr : attributes)
+            value |= attr.getFlagValue();
+
+        return value;
+    }
+
+    public static EnumSet<LockAttribute> getEnumSet (int bitfield) {
+        if (bitfield == 0)
+            return null;
+
+        EnumSet<LockAttribute> set = EnumSet.noneOf(LockAttribute.class);
+        for (LockAttribute attr : values()) {
+            if ((bitfield & attr.getFlagValue()) != 0)
+                set.add(attr);
+        }
+
+        return set;
+    }
+}


### PR DESCRIPTION
Do not merge this immediately.

I have not actually tested this change in-game.  My LP environment isn't building ATM and I don't have a good understanding of how to use the mod.

I'd appreciate it if the devs or any participants in #909 could build this locally and vet the changes.  

Besides a possible performance improvement for the attached issue (speculative and depends on what's actually in storage), the use of ISmartGroup puts most of the item routing decision in the hands of the controller, so slots are accessed according to specific priorities, and ore dictionary-compatible items can co-exist within the same controller network.  It should more closely mirror the AE2 behavior, at least as far as the variances in the AE2/LP APIs allow.
