### PR TITLE
Adding catch for NPE to RequestMonitorPopup

### DIFF
--- a/common/logisticspipes/gui/popup/RequestMonitorPopup.java
+++ b/common/logisticspipes/gui/popup/RequestMonitorPopup.java
@@ -277,7 +277,7 @@ public class RequestMonitorPopup extends SubGuiScreen {
 				try {
 					ImageIO.write(bufferedimage, "png", canidate);
 					Minecraft.getMinecraft().thePlayer.sendChatMessage("Saved tree view as " + canidate.getName());
-				} catch (IOException e) {
+				} catch (IOException|NullPointerException e) {
 					e.printStackTrace();
 				}
 				return;


### PR DESCRIPTION
Due to odd bug in ImageIO.write() it throws an NPE if it runs into an error writing to the directory. Added a catch to this to prevent a hard crash when saving.

Doesn't fix the underlying issue however, but this may not be easily solvable due to nature of the bug.
