### PR TITLE
Potential Fix for NullPointerException

### DIFF
--- a/common/logisticspipes/blocks/crafting/LogisticsCraftingTableTileEntity.java
+++ b/common/logisticspipes/blocks/crafting/LogisticsCraftingTableTileEntity.java
@@ -85,7 +85,7 @@ public class LogisticsCraftingTableTileEntity extends LogisticsSolidTileEntity i
 						craftInv.setInventorySlotContents(i, matrix.getStackInSlot(i));
 					}
 					ItemStack result = recipe.getCraftingResult(craftInv);
-					if (targetType.equals(ItemIdentifier.get(result))) {
+					if (result != null && targetType.equals(ItemIdentifier.get(result))) {
 						resultInv.setInventorySlotContents(0, result);
 						cache = recipe;
 						break;
@@ -93,10 +93,14 @@ public class LogisticsCraftingTableTileEntity extends LogisticsSolidTileEntity i
 				}
 			}
 			if (cache == null) {
-				cache = list.get(0);
-				ItemStack result = cache.getCraftingResult(craftInv);
-				resultInv.setInventorySlotContents(0, result);
-				targetType = ItemIdentifier.get(result);
+				for (IRecipe r : list) {
+					ItemStack result = r.getCraftingResult(craftInv);
+					if (result != null) {
+						cache = r;
+						resultInv.setInventorySlotContents(0, result);
+						targetType = ItemIdentifier.get(result);
+					}
+				}
 			}
 		} else {
 			targetType = null;

--- a/common/logisticspipes/blocks/crafting/LogisticsCraftingTableTileEntity.java
+++ b/common/logisticspipes/blocks/crafting/LogisticsCraftingTableTileEntity.java
@@ -99,6 +99,7 @@ public class LogisticsCraftingTableTileEntity extends LogisticsSolidTileEntity i
 						cache = r;
 						resultInv.setInventorySlotContents(0, result);
 						targetType = ItemIdentifier.get(result);
+						break;
 					}
 				}
 			}


### PR DESCRIPTION
Fixes a NullPointer issue that causes Logistics Crafting Tables to have
their matrices set to blank when loading worlds in certain modpacks.

(example:
https://gist.github.com/matthew117/601b8d3b37fbbba61c0f81bd21b10f76)
