### PR TITLE
Replace packet+gui class searcher code with more stable annotation-based resolver

### DIFF
--- a/common/logisticspipes/LogisticsPipes.java
+++ b/common/logisticspipes/LogisticsPipes.java
@@ -17,7 +17,6 @@ import java.util.Queue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import logisticspipes.utils.*;
 import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
@@ -183,6 +182,11 @@ import logisticspipes.ticks.RenderTickHandler;
 import logisticspipes.ticks.RoutingTableUpdateThread;
 import logisticspipes.ticks.ServerPacketBufferHandlerThread;
 import logisticspipes.ticks.VersionChecker;
+import logisticspipes.utils.FluidIdentifier;
+import logisticspipes.utils.InventoryUtilFactory;
+import logisticspipes.utils.RoutedItemHelper;
+import logisticspipes.utils.StaticResolverUtil;
+import logisticspipes.utils.TankUtilFactory;
 import logisticspipes.utils.tuples.Pair;
 import network.rs485.grow.TickExecutor;
 

--- a/common/logisticspipes/LogisticsPipes.java
+++ b/common/logisticspipes/LogisticsPipes.java
@@ -17,6 +17,7 @@ import java.util.Queue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import logisticspipes.utils.*;
 import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
@@ -182,10 +183,6 @@ import logisticspipes.ticks.RenderTickHandler;
 import logisticspipes.ticks.RoutingTableUpdateThread;
 import logisticspipes.ticks.ServerPacketBufferHandlerThread;
 import logisticspipes.ticks.VersionChecker;
-import logisticspipes.utils.FluidIdentifier;
-import logisticspipes.utils.InventoryUtilFactory;
-import logisticspipes.utils.RoutedItemHelper;
-import logisticspipes.utils.TankUtilFactory;
 import logisticspipes.utils.tuples.Pair;
 import network.rs485.grow.TickExecutor;
 
@@ -226,8 +223,6 @@ public class LogisticsPipes {
 			loader.registerTransformer("logisticspipes.asm.LogisticsPipesClassInjector");
 			e.printStackTrace();
 		}
-		PacketHandler.initialize();
-		NewGuiHandler.initialize();
 
 		MinecraftForge.EVENT_BUS.register(this);
 	}
@@ -395,6 +390,10 @@ public class LogisticsPipes {
 
 	@Mod.EventHandler
 	public void preInit(FMLPreInitializationEvent evt) {
+		StaticResolverUtil.useASMDataTable(evt.getAsmData());
+		PacketHandler.initialize();
+		NewGuiHandler.initialize();
+
 		LogisticsPipes.log = evt.getModLog();
 		loadClasses();
 		ProxyManager.load();

--- a/common/logisticspipes/network/NewGuiHandler.java
+++ b/common/logisticspipes/network/NewGuiHandler.java
@@ -1,43 +1,29 @@
 package logisticspipes.network;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-import java.util.stream.Collectors;
-
-import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.inventory.Container;
-
-import net.minecraftforge.fml.client.FMLClientHandler;
-import net.minecraftforge.fml.common.FMLCommonHandler;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
-
-import com.google.common.reflect.ClassPath;
-import com.google.common.reflect.ClassPath.ClassInfo;
-import lombok.SneakyThrows;
-
 import logisticspipes.LogisticsPipes;
 import logisticspipes.network.abstractguis.GuiProvider;
 import logisticspipes.network.abstractguis.PopupGuiProvider;
 import logisticspipes.network.exception.TargetNotFoundException;
 import logisticspipes.network.packets.gui.GUIPacket;
 import logisticspipes.proxy.MainProxy;
+import logisticspipes.utils.StaticResolverUtil;
 import logisticspipes.utils.gui.LogisticsBaseGuiScreen;
 import logisticspipes.utils.gui.SubGuiScreen;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.Container;
+import net.minecraftforge.fml.client.FMLClientHandler;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import network.rs485.logisticspipes.util.LPDataIOWrapper;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class NewGuiHandler {
 
@@ -52,64 +38,28 @@ public class NewGuiHandler {
 		return (T) NewGuiHandler.guimap.get(clazz).template();
 	}
 
-	@SuppressWarnings("unchecked")
-	@SneakyThrows({ IOException.class }) // , InvocationTargetException.class, IllegalAccessException.class, InstantiationException.class
-	// Suppression+sneakiness because these shouldn't ever fail, and if they do, it needs to fail.
-	public static final void initialize() {
-		final List<ClassInfo> classes = new ArrayList<>(ClassPath.from(NewGuiHandler.class.getClassLoader())
-				.getTopLevelClassesRecursive("logisticspipes.network.guis"));
+	public static void initialize() {
+		Set<Class<? extends GuiProvider>> classes = StaticResolverUtil.findClassesByType(GuiProvider.class);
 
-		loadGuiProvidersFromList(classes.stream().map(ClassInfo::getName).collect(Collectors.toList()));
+		loadGuiProviders(classes);
 
 		if (NewGuiHandler.guilist == null || NewGuiHandler.guilist.isEmpty()) {
-			System.err.println(
-					"LogisticsPipes could not search for its GuiProvider classes. Your mods are probably installed in a path containing spaces or special characters. Trying to use fallback solution.");
-			URL location = NewGuiHandler.class.getProtectionDomain().getCodeSource().getLocation();
-			String locationString = location.toString();
-			if (locationString.startsWith("jar:file:/") && locationString.contains("!")) {
-				locationString = locationString.substring(10, locationString.indexOf('!'));
-				locationString = java.net.URLDecoder.decode(locationString, "UTF-8");
-			}
-
-			List<String> classInfoList = new ArrayList<>();
-
-			File file = new File(locationString);
-			if (file.exists() && !file.isDirectory()) {
-				JarFile jar = new JarFile(file);
-				Enumeration<JarEntry> entriesS = jar.entries();
-				while (entriesS.hasMoreElements()) {
-					JarEntry entryB = entriesS.nextElement();
-					if (!entryB.isDirectory() && entryB.getName().startsWith("logisticspipes/network/guis/")) {
-						String filename = entryB.getName();
-						int classNameEnd = filename.length() - ".class".length();
-						filename = filename.substring(0, classNameEnd).replace('/', '.');
-						classInfoList.add(filename);
-					}
-				}
-			}
-
-			loadGuiProvidersFromList(classInfoList);
-
-			if (NewGuiHandler.guilist.isEmpty()) {
-				System.err.println("Fallback solution failed. Please try to move your minecraft folder to a different location.");
-				throw new RuntimeException("Cannot load GuiProvider Classes");
-			}
+			throw new RuntimeException("Cannot load GuiProvider Classes");
 		}
 	}
 
-	private static void loadGuiProvidersFromList(List<String> classes) {
-		classes.sort(Comparator.comparing(it -> it));
+	private static void loadGuiProviders(Set<Class<? extends GuiProvider>> classes) {
+		// classes.sort(Comparator.comparing(it -> it));
 
 		NewGuiHandler.guilist = new ArrayList<>(classes.size());
 		NewGuiHandler.guimap = new HashMap<>(classes.size());
 
 		int currentId = 0;
-		for (String c : classes) {
+		for (Class<? extends GuiProvider> cls : classes) {
 			try {
-				final Class<?> cls = PacketHandler.class.getClassLoader().loadClass(c);
 				final GuiProvider instance = (GuiProvider) cls.getConstructors()[0].newInstance(currentId);
 				NewGuiHandler.guilist.add(instance);
-				NewGuiHandler.guimap.put((Class<? extends GuiProvider>) cls, instance);
+				NewGuiHandler.guimap.put(cls, instance);
 				currentId++;
 			} catch (Throwable ignoredButPrinted) {
 				ignoredButPrinted.printStackTrace();
@@ -154,7 +104,7 @@ public class NewGuiHandler {
 		int guiID = packet.getGuiID();
 		GuiProvider provider = NewGuiHandler.guilist.get(guiID).template();
 		LPDataIOWrapper.provideData(packet.getGuiData(), provider::readData);
-		
+
 		if (provider instanceof PopupGuiProvider && packet.getWindowID() == -2) {
 			if (FMLClientHandler.instance().getClient().currentScreen instanceof LogisticsBaseGuiScreen) {
 				LogisticsBaseGuiScreen baseGUI = (LogisticsBaseGuiScreen) FMLClientHandler.instance().getClient().currentScreen;

--- a/common/logisticspipes/network/NewGuiHandler.java
+++ b/common/logisticspipes/network/NewGuiHandler.java
@@ -20,10 +20,12 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import network.rs485.logisticspipes.util.LPDataIOWrapper;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class NewGuiHandler {
 
@@ -48,8 +50,10 @@ public class NewGuiHandler {
 		}
 	}
 
-	private static void loadGuiProviders(Set<Class<? extends GuiProvider>> classes) {
-		// classes.sort(Comparator.comparing(it -> it));
+	private static void loadGuiProviders(Set<Class<? extends GuiProvider>> classesIn) {
+		List<Class<? extends GuiProvider>> classes = classesIn.stream()
+				.sorted(Comparator.comparing(Class::getCanonicalName))
+				.collect(Collectors.toList());
 
 		NewGuiHandler.guilist = new ArrayList<>(classes.size());
 		NewGuiHandler.guimap = new HashMap<>(classes.size());

--- a/common/logisticspipes/network/PacketHandler.java
+++ b/common/logisticspipes/network/PacketHandler.java
@@ -26,10 +26,12 @@ import network.rs485.logisticspipes.util.LPDataInput;
 import org.apache.logging.log4j.Level;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static io.netty.buffer.Unpooled.buffer;
 
@@ -74,8 +76,10 @@ public class PacketHandler extends MessageToMessageCodec<FMLProxyPacket, ModernP
 		}
 	}
 
-	private static void loadPackets(Set<Class<? extends ModernPacket>> classes) {
-		// classes.sort(Comparator.comparing(it -> it));
+	private static void loadPackets(Set<Class<? extends ModernPacket>> classesIn) {
+		List<Class<? extends ModernPacket>> classes = classesIn.stream()
+				.sorted(Comparator.comparing(Class::getCanonicalName))
+				.collect(Collectors.toList());
 
 		PacketHandler.packetlist = new ArrayList<>(classes.size());
 		PacketHandler.packetmap = new HashMap<>(classes.size());

--- a/common/logisticspipes/network/PacketHandler.java
+++ b/common/logisticspipes/network/PacketHandler.java
@@ -1,48 +1,37 @@
 package logisticspipes.network;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-import java.util.stream.Collectors;
-
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.network.PacketBuffer;
-
-import net.minecraftforge.fml.common.FMLLog;
-import net.minecraftforge.fml.common.network.NetworkRegistry;
-import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
-
-import com.google.common.reflect.ClassPath;
-import com.google.common.reflect.ClassPath.ClassInfo;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import static io.netty.buffer.Unpooled.buffer;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageCodec;
 import io.netty.util.AttributeKey;
-import lombok.SneakyThrows;
-import org.apache.logging.log4j.Level;
-
 import logisticspipes.LPConstants;
 import logisticspipes.LogisticsPipes;
 import logisticspipes.network.abstractpackets.ModernPacket;
 import logisticspipes.network.exception.DelayPacketException;
 import logisticspipes.proxy.MainProxy;
 import logisticspipes.proxy.SimpleServiceLocator;
+import logisticspipes.utils.StaticResolverUtil;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.PacketBuffer;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.network.NetworkRegistry;
+import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import network.rs485.logisticspipes.util.LPDataIOWrapper;
 import network.rs485.logisticspipes.util.LPDataInput;
+import org.apache.logging.log4j.Level;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static io.netty.buffer.Unpooled.buffer;
 
 /*
  *  Basically FML SimpleIndexedCodec, except with static registration of LP ModernPackets and short instead of byte discriminator
@@ -75,64 +64,28 @@ public class PacketHandler extends MessageToMessageCodec<FMLProxyPacket, ModernP
 	/*
 	 * enumerates all ModernPackets, sets their IDs and populate packetlist/packetmap
 	 */
-	@SuppressWarnings("unchecked")
-	@SneakyThrows({ IOException.class/*, InvocationTargetException.class, IllegalAccessException.class, InstantiationException.class, IllegalArgumentException.class, NoSuchMethodException.class, SecurityException.class*/ })
-	// Suppression+sneakiness because these shouldn't ever fail, and if they do, it needs to fail.
 	public static void initialize() {
-		final List<ClassInfo> classes = new ArrayList<>(ClassPath.from(PacketHandler.class.getClassLoader())
-				.getTopLevelClassesRecursive("logisticspipes.network.packets"));
+		Set<Class<? extends ModernPacket>> classes = StaticResolverUtil.findClassesByType(ModernPacket.class);
 
-		loadPacketsFromList(classes.stream().map(ClassInfo::getName).collect(Collectors.toList()));
+		loadPackets(classes);
 
 		if (PacketHandler.packetlist.isEmpty()) {
-			System.err.println(
-					"LogisticsPipes could not search for its packet classes. Your mods are probably installed in a path containing spaces or special characters. Trying to use fallback solution.");
-			URL location = PacketHandler.class.getProtectionDomain().getCodeSource().getLocation();
-			String locationString = location.toString();
-			if (locationString.startsWith("jar:file:/") && locationString.contains("!")) {
-				locationString = locationString.substring(10, locationString.indexOf('!'));
-				locationString = java.net.URLDecoder.decode(locationString, "UTF-8");
-			}
-
-			List<String> classInfoList = new ArrayList<>();
-
-			File file = new File(locationString);
-			if (file.exists() && !file.isDirectory()) {
-				JarFile jar = new JarFile(file);
-				Enumeration<JarEntry> entriesS = jar.entries();
-				while (entriesS.hasMoreElements()) {
-					JarEntry entryB = entriesS.nextElement();
-					if (!entryB.isDirectory() && entryB.getName().startsWith("logisticspipes/network/packets/")) {
-						String filename = entryB.getName();
-						int classNameEnd = filename.length() - ".class".length();
-						filename = filename.substring(0, classNameEnd).replace('/', '.');
-						classInfoList.add(filename);
-					}
-				}
-			}
-
-			loadPacketsFromList(classInfoList);
-
-			if (PacketHandler.packetlist.isEmpty()) {
-				System.err.println("Fallback solution failed. Please try to move your minecraft folder to a different location.");
-				throw new RuntimeException("Cannot load Packet Classes");
-			}
+			throw new RuntimeException("Cannot load Packet Classes");
 		}
 	}
 
-	private static void loadPacketsFromList(List<String> classes) {
-		classes.sort(Comparator.comparing(it -> it));
+	private static void loadPackets(Set<Class<? extends ModernPacket>> classes) {
+		// classes.sort(Comparator.comparing(it -> it));
 
 		PacketHandler.packetlist = new ArrayList<>(classes.size());
 		PacketHandler.packetmap = new HashMap<>(classes.size());
 
 		int currentId = 0;
-		for (String c : classes) {
+		for (Class<? extends ModernPacket> cls : classes) {
 			try {
-				final Class<?> cls = PacketHandler.class.getClassLoader().loadClass(c);
-				final ModernPacket instance = (ModernPacket) cls.getConstructor(int.class).newInstance(currentId);
+				final ModernPacket instance = cls.getConstructor(int.class).newInstance(currentId);
 				PacketHandler.packetlist.add(instance);
-				PacketHandler.packetmap.put((Class<? extends ModernPacket>) cls, instance);
+				PacketHandler.packetmap.put(cls, instance);
 				currentId++;
 			} catch (Throwable ignoredButPrinted) {
 				ignoredButPrinted.printStackTrace();

--- a/common/logisticspipes/network/guis/LogisticsPlayerSettingsGuiProvider.java
+++ b/common/logisticspipes/network/guis/LogisticsPlayerSettingsGuiProvider.java
@@ -7,6 +7,9 @@ import logisticspipes.utils.gui.DummyContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class LogisticsPlayerSettingsGuiProvider extends GuiProvider {
 
 	public LogisticsPlayerSettingsGuiProvider(int id) {

--- a/common/logisticspipes/network/guis/block/AutoCraftingGui.java
+++ b/common/logisticspipes/network/guis/block/AutoCraftingGui.java
@@ -11,6 +11,9 @@ import logisticspipes.utils.item.ItemIdentifier;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class AutoCraftingGui extends CoordinatesGuiProvider {
 
 	boolean isFuzzy;

--- a/common/logisticspipes/network/guis/block/PowerJunctionGui.java
+++ b/common/logisticspipes/network/guis/block/PowerJunctionGui.java
@@ -8,6 +8,9 @@ import logisticspipes.utils.gui.DummyContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PowerJunctionGui extends CoordinatesGuiProvider {
 
 	public PowerJunctionGui(int id) {

--- a/common/logisticspipes/network/guis/block/PowerProviderGui.java
+++ b/common/logisticspipes/network/guis/block/PowerProviderGui.java
@@ -8,6 +8,9 @@ import logisticspipes.utils.gui.DummyContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PowerProviderGui extends CoordinatesGuiProvider {
 
 	public PowerProviderGui(int id) {

--- a/common/logisticspipes/network/guis/block/ProgramCompilerGui.java
+++ b/common/logisticspipes/network/guis/block/ProgramCompilerGui.java
@@ -10,6 +10,9 @@ import logisticspipes.network.abstractguis.CoordinatesGuiProvider;
 import logisticspipes.network.abstractguis.GuiProvider;
 import logisticspipes.utils.gui.DummyContainer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ProgramCompilerGui extends CoordinatesGuiProvider {
 
 	public ProgramCompilerGui(int id) {

--- a/common/logisticspipes/network/guis/block/SecurityStationGui.java
+++ b/common/logisticspipes/network/guis/block/SecurityStationGui.java
@@ -9,6 +9,9 @@ import logisticspipes.utils.gui.DummyContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SecurityStationGui extends CoordinatesGuiProvider {
 
 	public SecurityStationGui(int id) {

--- a/common/logisticspipes/network/guis/block/SolderingStationGui.java
+++ b/common/logisticspipes/network/guis/block/SolderingStationGui.java
@@ -2,7 +2,6 @@ package logisticspipes.network.guis.block;
 
 import logisticspipes.blocks.LogisticsSolderingTileEntity;
 import logisticspipes.gui.GuiSolderingStation;
-import logisticspipes.interfaces.ISlotCheck;
 import logisticspipes.network.abstractguis.CoordinatesGuiProvider;
 import logisticspipes.network.abstractguis.GuiProvider;
 import logisticspipes.utils.gui.DummyContainer;
@@ -10,8 +9,10 @@ import logisticspipes.utils.gui.DummyContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SolderingStationGui extends CoordinatesGuiProvider {
 
 	public SolderingStationGui(int id) {

--- a/common/logisticspipes/network/guis/block/StatisticsGui.java
+++ b/common/logisticspipes/network/guis/block/StatisticsGui.java
@@ -17,6 +17,9 @@ import logisticspipes.utils.gui.DummyContainer;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class StatisticsGui extends CoordinatesGuiProvider {
 
 	@Getter

--- a/common/logisticspipes/network/guis/item/ItemAmountSignGui.java
+++ b/common/logisticspipes/network/guis/item/ItemAmountSignGui.java
@@ -16,6 +16,9 @@ import logisticspipes.utils.gui.DummyContainer;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ItemAmountSignGui extends CoordinatesGuiProvider {
 
 	@Getter

--- a/common/logisticspipes/network/guis/item/ItemMangerGui.java
+++ b/common/logisticspipes/network/guis/item/ItemMangerGui.java
@@ -3,15 +3,16 @@ package logisticspipes.network.guis.item;
 import logisticspipes.LogisticsPipes;
 import logisticspipes.gui.GuiCardManager;
 import logisticspipes.interfaces.IGuiOpenControler;
-import logisticspipes.interfaces.ISlotCheck;
 import logisticspipes.items.ItemModule;
 import logisticspipes.network.abstractguis.GuiProvider;
 import logisticspipes.utils.CardManagmentInventory;
 import logisticspipes.utils.gui.DummyContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ItemMangerGui extends GuiProvider {
 
 	public ItemMangerGui(int id) {

--- a/common/logisticspipes/network/guis/logic/LogicControllerGuiProvider.java
+++ b/common/logisticspipes/network/guis/logic/LogicControllerGuiProvider.java
@@ -11,6 +11,9 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.tileentity.TileEntity;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class LogicControllerGuiProvider extends CoordinatesGuiProvider {
 
 	public LogicControllerGuiProvider(int id) {

--- a/common/logisticspipes/network/guis/module/inhand/ActiveSupplierInHand.java
+++ b/common/logisticspipes/network/guis/module/inhand/ActiveSupplierInHand.java
@@ -10,6 +10,9 @@ import logisticspipes.utils.gui.DummyModuleContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ActiveSupplierInHand extends ModuleInHandGuiProvider {
 
 	public ActiveSupplierInHand(int id) {

--- a/common/logisticspipes/network/guis/module/inhand/AdvancedExtractorModuleInHand.java
+++ b/common/logisticspipes/network/guis/module/inhand/AdvancedExtractorModuleInHand.java
@@ -10,6 +10,9 @@ import logisticspipes.utils.gui.DummyModuleContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class AdvancedExtractorModuleInHand extends ModuleInHandGuiProvider {
 
 	public AdvancedExtractorModuleInHand(int id) {

--- a/common/logisticspipes/network/guis/module/inhand/ApiaristAnalyserModuleInHand.java
+++ b/common/logisticspipes/network/guis/module/inhand/ApiaristAnalyserModuleInHand.java
@@ -10,6 +10,9 @@ import logisticspipes.utils.gui.DummyModuleContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ApiaristAnalyserModuleInHand extends ModuleInHandGuiProvider {
 
 	public ApiaristAnalyserModuleInHand(int id) {

--- a/common/logisticspipes/network/guis/module/inhand/ApiaristSinkModuleInHand.java
+++ b/common/logisticspipes/network/guis/module/inhand/ApiaristSinkModuleInHand.java
@@ -11,6 +11,9 @@ import logisticspipes.utils.gui.DummyModuleContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ApiaristSinkModuleInHand extends ModuleInHandGuiProvider {
 
 	public ApiaristSinkModuleInHand(int id) {

--- a/common/logisticspipes/network/guis/module/inhand/CCBasedQuickSortInHand.java
+++ b/common/logisticspipes/network/guis/module/inhand/CCBasedQuickSortInHand.java
@@ -10,6 +10,9 @@ import logisticspipes.utils.gui.DummyModuleContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CCBasedQuickSortInHand extends ModuleInHandGuiProvider {
 
 	public CCBasedQuickSortInHand(int id) {

--- a/common/logisticspipes/network/guis/module/inhand/CraftingModuleInHand.java
+++ b/common/logisticspipes/network/guis/module/inhand/CraftingModuleInHand.java
@@ -16,6 +16,9 @@ import logisticspipes.utils.gui.DummyModuleContainer;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CraftingModuleInHand extends ModuleInHandGuiProvider {
 
 	@Getter

--- a/common/logisticspipes/network/guis/module/inhand/ElectricModuleInHand.java
+++ b/common/logisticspipes/network/guis/module/inhand/ElectricModuleInHand.java
@@ -10,6 +10,9 @@ import logisticspipes.utils.gui.DummyModuleContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ElectricModuleInHand extends ModuleInHandGuiProvider {
 
 	public ElectricModuleInHand(int id) {

--- a/common/logisticspipes/network/guis/module/inhand/ExtractorModuleInHand.java
+++ b/common/logisticspipes/network/guis/module/inhand/ExtractorModuleInHand.java
@@ -10,6 +10,9 @@ import logisticspipes.utils.gui.DummyModuleContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ExtractorModuleInHand extends ModuleInHandGuiProvider {
 
 	public ExtractorModuleInHand(int id) {

--- a/common/logisticspipes/network/guis/module/inhand/ItemSinkInHand.java
+++ b/common/logisticspipes/network/guis/module/inhand/ItemSinkInHand.java
@@ -10,6 +10,9 @@ import logisticspipes.utils.gui.DummyModuleContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ItemSinkInHand extends ModuleInHandGuiProvider {
 
 	public ItemSinkInHand(int id) {

--- a/common/logisticspipes/network/guis/module/inhand/OreDictItemSinkModuleInHand.java
+++ b/common/logisticspipes/network/guis/module/inhand/OreDictItemSinkModuleInHand.java
@@ -11,6 +11,9 @@ import logisticspipes.utils.item.ItemIdentifierInventory;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class OreDictItemSinkModuleInHand extends ModuleInHandGuiProvider {
 
 	public OreDictItemSinkModuleInHand(int id) {

--- a/common/logisticspipes/network/guis/module/inhand/ProviderModuleInHand.java
+++ b/common/logisticspipes/network/guis/module/inhand/ProviderModuleInHand.java
@@ -9,6 +9,9 @@ import logisticspipes.utils.gui.DummyModuleContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ProviderModuleInHand extends ModuleInHandGuiProvider {
 
 	public ProviderModuleInHand(int id) {

--- a/common/logisticspipes/network/guis/module/inhand/SimpleFilterInventoryInHand.java
+++ b/common/logisticspipes/network/guis/module/inhand/SimpleFilterInventoryInHand.java
@@ -10,6 +10,9 @@ import logisticspipes.utils.gui.DummyModuleContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SimpleFilterInventoryInHand extends ModuleInHandGuiProvider {
 
 	public SimpleFilterInventoryInHand(int id) {

--- a/common/logisticspipes/network/guis/module/inhand/StringBasedItemSinkModuleGuiInHand.java
+++ b/common/logisticspipes/network/guis/module/inhand/StringBasedItemSinkModuleGuiInHand.java
@@ -11,6 +11,9 @@ import logisticspipes.utils.item.ItemIdentifierInventory;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class StringBasedItemSinkModuleGuiInHand extends ModuleInHandGuiProvider {
 
 	public StringBasedItemSinkModuleGuiInHand(int id) {

--- a/common/logisticspipes/network/guis/module/inpipe/ActiveSupplierSlot.java
+++ b/common/logisticspipes/network/guis/module/inpipe/ActiveSupplierSlot.java
@@ -15,6 +15,9 @@ import logisticspipes.utils.gui.DummyContainer;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ActiveSupplierSlot extends ModuleCoordinatesGuiProvider {
 
 	@Getter

--- a/common/logisticspipes/network/guis/module/inpipe/AdvancedExtractorModuleSlot.java
+++ b/common/logisticspipes/network/guis/module/inpipe/AdvancedExtractorModuleSlot.java
@@ -13,6 +13,9 @@ import logisticspipes.utils.gui.DummyContainer;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class AdvancedExtractorModuleSlot extends ModuleCoordinatesGuiProvider {
 
 	@Getter

--- a/common/logisticspipes/network/guis/module/inpipe/ApiaristAnalyzerModuleSlot.java
+++ b/common/logisticspipes/network/guis/module/inpipe/ApiaristAnalyzerModuleSlot.java
@@ -13,6 +13,9 @@ import logisticspipes.utils.gui.DummyContainer;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ApiaristAnalyzerModuleSlot extends ModuleCoordinatesGuiProvider {
 
 	@Getter

--- a/common/logisticspipes/network/guis/module/inpipe/ApiaristSinkModuleSlot.java
+++ b/common/logisticspipes/network/guis/module/inpipe/ApiaristSinkModuleSlot.java
@@ -9,6 +9,9 @@ import logisticspipes.utils.gui.DummyContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ApiaristSinkModuleSlot extends NBTModuleCoordinatesGuiProvider {
 
 	public ApiaristSinkModuleSlot(int id) {

--- a/common/logisticspipes/network/guis/module/inpipe/CCBasedQuickSortSlot.java
+++ b/common/logisticspipes/network/guis/module/inpipe/CCBasedQuickSortSlot.java
@@ -13,6 +13,9 @@ import logisticspipes.utils.gui.DummyContainer;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CCBasedQuickSortSlot extends ModuleCoordinatesGuiProvider {
 
 	@Getter

--- a/common/logisticspipes/network/guis/module/inpipe/CraftingModuleSlot.java
+++ b/common/logisticspipes/network/guis/module/inpipe/CraftingModuleSlot.java
@@ -14,6 +14,9 @@ import logisticspipes.utils.gui.DummyContainer;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CraftingModuleSlot extends ModuleCoordinatesGuiProvider {
 
 	@Getter

--- a/common/logisticspipes/network/guis/module/inpipe/ElectricModuleSlot.java
+++ b/common/logisticspipes/network/guis/module/inpipe/ElectricModuleSlot.java
@@ -8,6 +8,9 @@ import logisticspipes.utils.gui.DummyContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ElectricModuleSlot extends BooleanModuleCoordinatesGuiProvider {
 
 	public ElectricModuleSlot(int id) {

--- a/common/logisticspipes/network/guis/module/inpipe/ExtractorModuleSlot.java
+++ b/common/logisticspipes/network/guis/module/inpipe/ExtractorModuleSlot.java
@@ -14,6 +14,9 @@ import logisticspipes.utils.gui.DummyContainer;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ExtractorModuleSlot extends ModuleCoordinatesGuiProvider {
 
 	@Getter

--- a/common/logisticspipes/network/guis/module/inpipe/FluidSupplierSlot.java
+++ b/common/logisticspipes/network/guis/module/inpipe/FluidSupplierSlot.java
@@ -8,6 +8,9 @@ import logisticspipes.network.abstractguis.GuiProvider;
 import logisticspipes.network.abstractguis.ModuleCoordinatesGuiProvider;
 import logisticspipes.utils.gui.DummyContainer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class FluidSupplierSlot extends ModuleCoordinatesGuiProvider {
 
 	public FluidSupplierSlot(int id) {

--- a/common/logisticspipes/network/guis/module/inpipe/ItemSinkSlot.java
+++ b/common/logisticspipes/network/guis/module/inpipe/ItemSinkSlot.java
@@ -15,6 +15,9 @@ import logisticspipes.utils.gui.DummyContainer;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ItemSinkSlot extends ModuleCoordinatesGuiProvider {
 
 	@Getter

--- a/common/logisticspipes/network/guis/module/inpipe/OreDictItemSinkModuleSlot.java
+++ b/common/logisticspipes/network/guis/module/inpipe/OreDictItemSinkModuleSlot.java
@@ -9,6 +9,9 @@ import logisticspipes.utils.item.ItemIdentifierInventory;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class OreDictItemSinkModuleSlot extends NBTModuleCoordinatesGuiProvider {
 
 	public OreDictItemSinkModuleSlot(int id) {

--- a/common/logisticspipes/network/guis/module/inpipe/ProviderModuleGuiProvider.java
+++ b/common/logisticspipes/network/guis/module/inpipe/ProviderModuleGuiProvider.java
@@ -13,6 +13,9 @@ import logisticspipes.utils.gui.DummyContainer;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ProviderModuleGuiProvider extends ModuleCoordinatesGuiProvider {
 
 	@Getter

--- a/common/logisticspipes/network/guis/module/inpipe/SimpleFilterInventorySlot.java
+++ b/common/logisticspipes/network/guis/module/inpipe/SimpleFilterInventorySlot.java
@@ -8,6 +8,9 @@ import logisticspipes.utils.gui.DummyContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SimpleFilterInventorySlot extends ModuleCoordinatesGuiProvider {
 
 	public SimpleFilterInventorySlot(int id) {

--- a/common/logisticspipes/network/guis/module/inpipe/StringBasedItemSinkModuleGuiSlot.java
+++ b/common/logisticspipes/network/guis/module/inpipe/StringBasedItemSinkModuleGuiSlot.java
@@ -9,6 +9,9 @@ import logisticspipes.network.abstractguis.NBTModuleCoordinatesGuiProvider;
 import logisticspipes.utils.gui.DummyContainer;
 import logisticspipes.utils.item.ItemIdentifierInventory;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class StringBasedItemSinkModuleGuiSlot extends NBTModuleCoordinatesGuiProvider {
 
 	public StringBasedItemSinkModuleGuiSlot(int id) {

--- a/common/logisticspipes/network/guis/pipe/ChassiGuiProvider.java
+++ b/common/logisticspipes/network/guis/pipe/ChassiGuiProvider.java
@@ -4,7 +4,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 
-import logisticspipes.LogisticsPipes;
 import logisticspipes.gui.GuiChassiPipe;
 import logisticspipes.items.ItemUpgrade;
 import logisticspipes.modules.abstractmodules.LogisticsModule;
@@ -15,6 +14,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import logisticspipes.pipes.upgrades.ModuleUpgradeManager;
 import logisticspipes.utils.gui.DummyContainer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ChassiGuiProvider extends BooleanModuleCoordinatesGuiProvider {
 
 	public ChassiGuiProvider(int id) {

--- a/common/logisticspipes/network/guis/pipe/PipeController.java
+++ b/common/logisticspipes/network/guis/pipe/PipeController.java
@@ -18,6 +18,9 @@ import logisticspipes.pipes.upgrades.SneakyUpgradeConfig;
 import logisticspipes.proxy.SimpleServiceLocator;
 import logisticspipes.utils.gui.DummyContainer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PipeController extends CoordinatesGuiProvider {
 
 	public PipeController(int id) {

--- a/common/logisticspipes/network/guis/upgrade/DisconnectionUpgradeConfigGuiProvider.java
+++ b/common/logisticspipes/network/guis/upgrade/DisconnectionUpgradeConfigGuiProvider.java
@@ -9,6 +9,9 @@ import logisticspipes.pipes.basic.CoreRoutedPipe;
 import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import logisticspipes.utils.gui.UpgradeSlot;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class DisconnectionUpgradeConfigGuiProvider extends UpgradeCoordinatesGuiProvider {
 
 	public DisconnectionUpgradeConfigGuiProvider(int id) {

--- a/common/logisticspipes/network/guis/upgrade/SneakyUpgradeConfigGuiProvider.java
+++ b/common/logisticspipes/network/guis/upgrade/SneakyUpgradeConfigGuiProvider.java
@@ -15,6 +15,9 @@ import logisticspipes.utils.gui.UpgradeSlot;
 import network.rs485.logisticspipes.world.DoubleCoordinates;
 import network.rs485.logisticspipes.world.WorldCoordinatesWrapper;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SneakyUpgradeConfigGuiProvider extends UpgradeCoordinatesGuiProvider {
 
 	public SneakyUpgradeConfigGuiProvider(int id) {

--- a/common/logisticspipes/network/packets/ActivateNBTDebug.java
+++ b/common/logisticspipes/network/packets/ActivateNBTDebug.java
@@ -9,6 +9,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ActivateNBTDebug extends ModernPacket {
 
 	public ActivateNBTDebug(int id) {

--- a/common/logisticspipes/network/packets/BufferTransfer.java
+++ b/common/logisticspipes/network/packets/BufferTransfer.java
@@ -11,6 +11,9 @@ import logisticspipes.proxy.SimpleServiceLocator;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class BufferTransfer extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/DummyPacket.java
+++ b/common/logisticspipes/network/packets/DummyPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class DummyPacket extends ModernPacket {
 
 	public DummyPacket(int id) {

--- a/common/logisticspipes/network/packets/NEISetCraftingRecipe.java
+++ b/common/logisticspipes/network/packets/NEISetCraftingRecipe.java
@@ -16,6 +16,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class NEISetCraftingRecipe extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/PlayerConfigToClientPacket.java
+++ b/common/logisticspipes/network/packets/PlayerConfigToClientPacket.java
@@ -11,6 +11,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PlayerConfigToClientPacket extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/PlayerConfigToServerPacket.java
+++ b/common/logisticspipes/network/packets/PlayerConfigToServerPacket.java
@@ -12,6 +12,9 @@ import logisticspipes.utils.PlayerIdentifier;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PlayerConfigToServerPacket extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/PlayerList.java
+++ b/common/logisticspipes/network/packets/PlayerList.java
@@ -8,6 +8,9 @@ import logisticspipes.interfaces.PlayerListReciver;
 import logisticspipes.network.abstractpackets.ModernPacket;
 import logisticspipes.network.abstractpackets.StringListPacket;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PlayerList extends StringListPacket {
 
 	public PlayerList(int id) {

--- a/common/logisticspipes/network/packets/PlayerListRequest.java
+++ b/common/logisticspipes/network/packets/PlayerListRequest.java
@@ -15,6 +15,9 @@ import logisticspipes.proxy.MainProxy;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PlayerListRequest extends ModernPacket {
 
 	public PlayerListRequest(int id) {

--- a/common/logisticspipes/network/packets/RequestUpdateNamesPacket.java
+++ b/common/logisticspipes/network/packets/RequestUpdateNamesPacket.java
@@ -1,6 +1,5 @@
 package logisticspipes.network.packets;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,6 +20,9 @@ import logisticspipes.utils.item.ItemIdentifier;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RequestUpdateNamesPacket extends ModernPacket {
 
 	public RequestUpdateNamesPacket(int id) {

--- a/common/logisticspipes/network/packets/UpdateName.java
+++ b/common/logisticspipes/network/packets/UpdateName.java
@@ -12,6 +12,9 @@ import logisticspipes.utils.item.ItemIdentifier;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class UpdateName extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/block/AddItemToTrackPacket.java
+++ b/common/logisticspipes/network/packets/block/AddItemToTrackPacket.java
@@ -13,6 +13,9 @@ import logisticspipes.utils.item.ItemIdentifier;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class AddItemToTrackPacket extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/block/AmountTaskSubGui.java
+++ b/common/logisticspipes/network/packets/block/AmountTaskSubGui.java
@@ -8,6 +8,9 @@ import net.minecraft.entity.player.EntityPlayer;
 
 import net.minecraftforge.fml.client.FMLClientHandler;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class AmountTaskSubGui extends InventoryModuleCoordinatesPacket {
 
 	public AmountTaskSubGui(int id) {

--- a/common/logisticspipes/network/packets/block/ClearCraftingGridPacket.java
+++ b/common/logisticspipes/network/packets/block/ClearCraftingGridPacket.java
@@ -8,6 +8,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ClearCraftingGridPacket extends CoordinatesPacket {
 
 	public ClearCraftingGridPacket(int id) {

--- a/common/logisticspipes/network/packets/block/CompilerStatusPacket.java
+++ b/common/logisticspipes/network/packets/block/CompilerStatusPacket.java
@@ -13,6 +13,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CompilerStatusPacket extends CoordinatesPacket {
 
 	public CompilerStatusPacket(int id) {

--- a/common/logisticspipes/network/packets/block/CompilerTriggerTaskPacket.java
+++ b/common/logisticspipes/network/packets/block/CompilerTriggerTaskPacket.java
@@ -12,6 +12,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CompilerTriggerTaskPacket extends CoordinatesPacket {
 
 	public CompilerTriggerTaskPacket(int id) {

--- a/common/logisticspipes/network/packets/block/CraftingCycleRecipe.java
+++ b/common/logisticspipes/network/packets/block/CraftingCycleRecipe.java
@@ -14,6 +14,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CraftingCycleRecipe extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/block/CraftingPipeNextAdvancedSatellitePacket.java
+++ b/common/logisticspipes/network/packets/block/CraftingPipeNextAdvancedSatellitePacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CraftingPipeNextAdvancedSatellitePacket extends IntegerModuleCoordinatesPacket {
 
 	public CraftingPipeNextAdvancedSatellitePacket(int id) {

--- a/common/logisticspipes/network/packets/block/CraftingPipePrevAdvancedSatellitePacket.java
+++ b/common/logisticspipes/network/packets/block/CraftingPipePrevAdvancedSatellitePacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CraftingPipePrevAdvancedSatellitePacket extends IntegerModuleCoordinatesPacket {
 
 	public CraftingPipePrevAdvancedSatellitePacket(int id) {

--- a/common/logisticspipes/network/packets/block/CraftingSetType.java
+++ b/common/logisticspipes/network/packets/block/CraftingSetType.java
@@ -15,6 +15,9 @@ import logisticspipes.utils.item.ItemIdentifier;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CraftingSetType extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/block/LogicControllerPacket.java
+++ b/common/logisticspipes/network/packets/block/LogicControllerPacket.java
@@ -9,6 +9,9 @@ import logisticspipes.network.guis.logic.LogicControllerGuiProvider;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class LogicControllerPacket extends CoordinatesPacket {
 
 	public LogicControllerPacket(int id) {

--- a/common/logisticspipes/network/packets/block/PipeSolidSideCheck.java
+++ b/common/logisticspipes/network/packets/block/PipeSolidSideCheck.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.IntegerCoordinatesPacket;
 import logisticspipes.network.abstractpackets.ModernPacket;
 import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PipeSolidSideCheck extends IntegerCoordinatesPacket {
 
 	public PipeSolidSideCheck(int id) {

--- a/common/logisticspipes/network/packets/block/PowerJunctionCheatPacket.java
+++ b/common/logisticspipes/network/packets/block/PowerJunctionCheatPacket.java
@@ -7,6 +7,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PowerJunctionCheatPacket extends CoordinatesPacket {
 
 	public PowerJunctionCheatPacket(int id) {

--- a/common/logisticspipes/network/packets/block/PowerJunctionLevel.java
+++ b/common/logisticspipes/network/packets/block/PowerJunctionLevel.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PowerJunctionLevel extends IntegerCoordinatesPacket {
 
 	public PowerJunctionLevel(int id) {

--- a/common/logisticspipes/network/packets/block/PowerPacketLaser.java
+++ b/common/logisticspipes/network/packets/block/PowerPacketLaser.java
@@ -12,6 +12,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PowerPacketLaser extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/block/PowerProviderLevel.java
+++ b/common/logisticspipes/network/packets/block/PowerProviderLevel.java
@@ -8,6 +8,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PowerProviderLevel extends CoordinatesPacket {
 
 	private Double aDouble;

--- a/common/logisticspipes/network/packets/block/RemoveAmoundTask.java
+++ b/common/logisticspipes/network/packets/block/RemoveAmoundTask.java
@@ -15,6 +15,9 @@ import logisticspipes.utils.item.ItemIdentifier;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RemoveAmoundTask extends CoordinatesPacket {
 
 	@Setter

--- a/common/logisticspipes/network/packets/block/RequestAmountTaskSubGui.java
+++ b/common/logisticspipes/network/packets/block/RequestAmountTaskSubGui.java
@@ -17,6 +17,9 @@ import logisticspipes.utils.item.ItemIdentifierStack;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RequestAmountTaskSubGui extends CoordinatesPacket {
 
 	public RequestAmountTaskSubGui(int id) {

--- a/common/logisticspipes/network/packets/block/RequestRotationPacket.java
+++ b/common/logisticspipes/network/packets/block/RequestRotationPacket.java
@@ -8,6 +8,9 @@ import logisticspipes.proxy.MainProxy;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RequestRotationPacket extends CoordinatesPacket {
 
 	public RequestRotationPacket(int id) {

--- a/common/logisticspipes/network/packets/block/RequestRunningCraftingTasks.java
+++ b/common/logisticspipes/network/packets/block/RequestRunningCraftingTasks.java
@@ -15,6 +15,9 @@ import logisticspipes.utils.item.ItemIdentifierStack;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RequestRunningCraftingTasks extends CoordinatesPacket {
 
 	public RequestRunningCraftingTasks(int id) {

--- a/common/logisticspipes/network/packets/block/Rotation.java
+++ b/common/logisticspipes/network/packets/block/Rotation.java
@@ -7,8 +7,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.math.BlockPos;
 
-import net.minecraftforge.fml.client.FMLClientHandler;
+import logisticspipes.utils.StaticResolve;
 
+@StaticResolve
 public class Rotation extends IntegerCoordinatesPacket {
 
 	public Rotation(int id) {

--- a/common/logisticspipes/network/packets/block/RunningCraftingTasks.java
+++ b/common/logisticspipes/network/packets/block/RunningCraftingTasks.java
@@ -15,6 +15,9 @@ import logisticspipes.utils.item.ItemIdentifierStack;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RunningCraftingTasks extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/block/SaveSecurityPlayerPacket.java
+++ b/common/logisticspipes/network/packets/block/SaveSecurityPlayerPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.NBTCoordinatesPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SaveSecurityPlayerPacket extends NBTCoordinatesPacket {
 
 	public SaveSecurityPlayerPacket(int id) {

--- a/common/logisticspipes/network/packets/block/SecurityAddCCIdPacket.java
+++ b/common/logisticspipes/network/packets/block/SecurityAddCCIdPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SecurityAddCCIdPacket extends IntegerCoordinatesPacket {
 
 	public SecurityAddCCIdPacket(int id) {

--- a/common/logisticspipes/network/packets/block/SecurityAuthorizationPacket.java
+++ b/common/logisticspipes/network/packets/block/SecurityAuthorizationPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SecurityAuthorizationPacket extends IntegerCoordinatesPacket {
 
 	public SecurityAuthorizationPacket(int id) {

--- a/common/logisticspipes/network/packets/block/SecurityCardPacket.java
+++ b/common/logisticspipes/network/packets/block/SecurityCardPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SecurityCardPacket extends IntegerCoordinatesPacket {
 
 	public SecurityCardPacket(int id) {

--- a/common/logisticspipes/network/packets/block/SecurityRemoveCCIdPacket.java
+++ b/common/logisticspipes/network/packets/block/SecurityRemoveCCIdPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SecurityRemoveCCIdPacket extends IntegerCoordinatesPacket {
 
 	public SecurityRemoveCCIdPacket(int id) {

--- a/common/logisticspipes/network/packets/block/SecurityRequestCCIdsPacket.java
+++ b/common/logisticspipes/network/packets/block/SecurityRequestCCIdsPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SecurityRequestCCIdsPacket extends CoordinatesPacket {
 
 	public SecurityRequestCCIdsPacket(int id) {

--- a/common/logisticspipes/network/packets/block/SecurityStationAuthorizedList.java
+++ b/common/logisticspipes/network/packets/block/SecurityStationAuthorizedList.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import logisticspipes.network.abstractpackets.StringListPacket;
 import logisticspipes.proxy.SimpleServiceLocator;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SecurityStationAuthorizedList extends StringListPacket {
 
 	public SecurityStationAuthorizedList(int id) {

--- a/common/logisticspipes/network/packets/block/SecurityStationAutoDestroy.java
+++ b/common/logisticspipes/network/packets/block/SecurityStationAutoDestroy.java
@@ -12,6 +12,9 @@ import logisticspipes.network.abstractpackets.IntegerCoordinatesPacket;
 import logisticspipes.network.abstractpackets.ModernPacket;
 import logisticspipes.proxy.MainProxy;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SecurityStationAutoDestroy extends IntegerCoordinatesPacket {
 
 	public SecurityStationAutoDestroy(int id) {

--- a/common/logisticspipes/network/packets/block/SecurityStationCC.java
+++ b/common/logisticspipes/network/packets/block/SecurityStationCC.java
@@ -12,6 +12,9 @@ import logisticspipes.network.abstractpackets.IntegerCoordinatesPacket;
 import logisticspipes.network.abstractpackets.ModernPacket;
 import logisticspipes.proxy.MainProxy;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SecurityStationCC extends IntegerCoordinatesPacket {
 
 	public SecurityStationCC(int id) {

--- a/common/logisticspipes/network/packets/block/SecurityStationCCIDs.java
+++ b/common/logisticspipes/network/packets/block/SecurityStationCCIDs.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.NBTCoordinatesPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SecurityStationCCIDs extends NBTCoordinatesPacket {
 
 	public SecurityStationCCIDs(int id) {

--- a/common/logisticspipes/network/packets/block/SecurityStationId.java
+++ b/common/logisticspipes/network/packets/block/SecurityStationId.java
@@ -13,6 +13,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SecurityStationId extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/block/SecurityStationOpenPlayer.java
+++ b/common/logisticspipes/network/packets/block/SecurityStationOpenPlayer.java
@@ -12,6 +12,9 @@ import logisticspipes.network.abstractpackets.NBTCoordinatesPacket;
 import logisticspipes.proxy.MainProxy;
 import logisticspipes.security.SecuritySettings;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SecurityStationOpenPlayer extends NBTCoordinatesPacket {
 
 	public SecurityStationOpenPlayer(int id) {

--- a/common/logisticspipes/network/packets/block/SecurityStationOpenPlayerRequest.java
+++ b/common/logisticspipes/network/packets/block/SecurityStationOpenPlayerRequest.java
@@ -6,6 +6,9 @@ import logisticspipes.blocks.LogisticsSecurityTileEntity;
 import logisticspipes.network.abstractpackets.ModernPacket;
 import logisticspipes.network.abstractpackets.StringCoordinatesPacket;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SecurityStationOpenPlayerRequest extends StringCoordinatesPacket {
 
 	public SecurityStationOpenPlayerRequest(int id) {

--- a/common/logisticspipes/network/packets/block/SolderingStationHeat.java
+++ b/common/logisticspipes/network/packets/block/SolderingStationHeat.java
@@ -7,6 +7,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.math.BlockPos;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SolderingStationHeat extends IntegerCoordinatesPacket {
 
 	public SolderingStationHeat(int id) {

--- a/common/logisticspipes/network/packets/block/SolderingStationInventory.java
+++ b/common/logisticspipes/network/packets/block/SolderingStationInventory.java
@@ -7,6 +7,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SolderingStationInventory extends InventoryModuleCoordinatesPacket {
 
 	public SolderingStationInventory(int id) {

--- a/common/logisticspipes/network/packets/block/SolderingStationProgress.java
+++ b/common/logisticspipes/network/packets/block/SolderingStationProgress.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SolderingStationProgress extends IntegerCoordinatesPacket {
 
 	public SolderingStationProgress(int id) {

--- a/common/logisticspipes/network/packets/chassis/ChassisGUI.java
+++ b/common/logisticspipes/network/packets/chassis/ChassisGUI.java
@@ -13,6 +13,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ChassisGUI extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/chassis/ChestGuiClosed.java
+++ b/common/logisticspipes/network/packets/chassis/ChestGuiClosed.java
@@ -11,6 +11,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ChestGuiClosed extends ModernPacket {
 
 	public ChestGuiClosed(int id) {

--- a/common/logisticspipes/network/packets/chassis/ChestGuiOpened.java
+++ b/common/logisticspipes/network/packets/chassis/ChestGuiOpened.java
@@ -13,6 +13,9 @@ import logisticspipes.proxy.MainProxy;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ChestGuiOpened extends ModernPacket {
 
 	public ChestGuiOpened(int id) {

--- a/common/logisticspipes/network/packets/chassis/EnableQuickSortMarker.java
+++ b/common/logisticspipes/network/packets/chassis/EnableQuickSortMarker.java
@@ -7,6 +7,9 @@ import logisticspipes.utils.QuickSortChestMarkerStorage;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class EnableQuickSortMarker extends ModernPacket {
 
 	public EnableQuickSortMarker(int id) {

--- a/common/logisticspipes/network/packets/cpipe/CPipeCleanupImport.java
+++ b/common/logisticspipes/network/packets/cpipe/CPipeCleanupImport.java
@@ -8,6 +8,9 @@ import logisticspipes.proxy.MainProxy;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CPipeCleanupImport extends ModuleCoordinatesPacket {
 
 	public CPipeCleanupImport(int id) {

--- a/common/logisticspipes/network/packets/cpipe/CPipeCleanupStatus.java
+++ b/common/logisticspipes/network/packets/cpipe/CPipeCleanupStatus.java
@@ -14,6 +14,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CPipeCleanupStatus extends ModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/cpipe/CPipeCleanupToggle.java
+++ b/common/logisticspipes/network/packets/cpipe/CPipeCleanupToggle.java
@@ -8,6 +8,9 @@ import logisticspipes.proxy.MainProxy;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CPipeCleanupToggle extends ModuleCoordinatesPacket {
 
 	public CPipeCleanupToggle(int id) {

--- a/common/logisticspipes/network/packets/cpipe/CPipeNextSatellite.java
+++ b/common/logisticspipes/network/packets/cpipe/CPipeNextSatellite.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CPipeNextSatellite extends ModuleCoordinatesPacket {
 
 	public CPipeNextSatellite(int id) {

--- a/common/logisticspipes/network/packets/cpipe/CPipePrevSatellite.java
+++ b/common/logisticspipes/network/packets/cpipe/CPipePrevSatellite.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CPipePrevSatellite extends ModuleCoordinatesPacket {
 
 	public CPipePrevSatellite(int id) {

--- a/common/logisticspipes/network/packets/cpipe/CPipeSatelliteId.java
+++ b/common/logisticspipes/network/packets/cpipe/CPipeSatelliteId.java
@@ -11,6 +11,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CPipeSatelliteId extends ModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/cpipe/CPipeSatelliteImport.java
+++ b/common/logisticspipes/network/packets/cpipe/CPipeSatelliteImport.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CPipeSatelliteImport extends ModuleCoordinatesPacket {
 
 	public CPipeSatelliteImport(int id) {

--- a/common/logisticspipes/network/packets/cpipe/CPipeSatelliteImportBack.java
+++ b/common/logisticspipes/network/packets/cpipe/CPipeSatelliteImportBack.java
@@ -6,6 +6,9 @@ import logisticspipes.modules.ModuleCrafter;
 import logisticspipes.network.abstractpackets.InventoryModuleCoordinatesPacket;
 import logisticspipes.network.abstractpackets.ModernPacket;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CPipeSatelliteImportBack extends InventoryModuleCoordinatesPacket {
 
 	public CPipeSatelliteImportBack(int id) {

--- a/common/logisticspipes/network/packets/cpipe/CraftingAdvancedSatelliteId.java
+++ b/common/logisticspipes/network/packets/cpipe/CraftingAdvancedSatelliteId.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CraftingAdvancedSatelliteId extends Integer2ModuleCoordinatesPacket {
 
 	public CraftingAdvancedSatelliteId(int id) {

--- a/common/logisticspipes/network/packets/cpipe/CraftingPipeOpenConnectedGuiPacket.java
+++ b/common/logisticspipes/network/packets/cpipe/CraftingPipeOpenConnectedGuiPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CraftingPipeOpenConnectedGuiPacket extends ModuleCoordinatesPacket {
 
 	public CraftingPipeOpenConnectedGuiPacket(int id) {

--- a/common/logisticspipes/network/packets/debug/PipeDebugLogAskForTarget.java
+++ b/common/logisticspipes/network/packets/debug/PipeDebugLogAskForTarget.java
@@ -13,6 +13,9 @@ import logisticspipes.proxy.MainProxy;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PipeDebugLogAskForTarget extends ModernPacket {
 
 	public PipeDebugLogAskForTarget(int id) {

--- a/common/logisticspipes/network/packets/debug/PipeDebugLogResponse.java
+++ b/common/logisticspipes/network/packets/debug/PipeDebugLogResponse.java
@@ -8,6 +8,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.text.TextComponentString;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PipeDebugLogResponse extends CoordinatesPacket {
 
 	public PipeDebugLogResponse(int id) {

--- a/common/logisticspipes/network/packets/debug/SendNewLogLine.java
+++ b/common/logisticspipes/network/packets/debug/SendNewLogLine.java
@@ -10,6 +10,9 @@ import logisticspipes.pipes.basic.debug.LogWindow;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SendNewLogLine extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/debug/SendNewLogWindow.java
+++ b/common/logisticspipes/network/packets/debug/SendNewLogWindow.java
@@ -10,6 +10,9 @@ import logisticspipes.pipes.basic.debug.LogWindow;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SendNewLogWindow extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/debug/UpdateStatusEntries.java
+++ b/common/logisticspipes/network/packets/debug/UpdateStatusEntries.java
@@ -15,6 +15,9 @@ import logisticspipes.pipes.basic.debug.StatusEntry;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class UpdateStatusEntries extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/debuggui/DebugAskForTarget.java
+++ b/common/logisticspipes/network/packets/debuggui/DebugAskForTarget.java
@@ -11,6 +11,9 @@ import logisticspipes.proxy.MainProxy;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class DebugAskForTarget extends ModernPacket {
 
 	public DebugAskForTarget(int id) {

--- a/common/logisticspipes/network/packets/debuggui/DebugDataPacket.java
+++ b/common/logisticspipes/network/packets/debuggui/DebugDataPacket.java
@@ -10,6 +10,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class DebugDataPacket extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/debuggui/DebugPanelOpen.java
+++ b/common/logisticspipes/network/packets/debuggui/DebugPanelOpen.java
@@ -10,6 +10,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class DebugPanelOpen extends ModernPacket {
 
 	@Setter

--- a/common/logisticspipes/network/packets/debuggui/DebugTargetResponse.java
+++ b/common/logisticspipes/network/packets/debuggui/DebugTargetResponse.java
@@ -20,6 +20,9 @@ import logisticspipes.utils.string.ChatColor;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class DebugTargetResponse extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/gui/DummyContainerSlotClick.java
+++ b/common/logisticspipes/network/packets/gui/DummyContainerSlotClick.java
@@ -18,6 +18,9 @@ import logisticspipes.utils.item.ItemIdentifierStack;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class DummyContainerSlotClick extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/gui/FuzzySlotSettingsPacket.java
+++ b/common/logisticspipes/network/packets/gui/FuzzySlotSettingsPacket.java
@@ -12,6 +12,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class FuzzySlotSettingsPacket extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/gui/GUIPacket.java
+++ b/common/logisticspipes/network/packets/gui/GUIPacket.java
@@ -11,6 +11,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class GUIPacket extends ModernPacket {
 
 	/**

--- a/common/logisticspipes/network/packets/gui/GuiOpenChassie.java
+++ b/common/logisticspipes/network/packets/gui/GuiOpenChassie.java
@@ -10,6 +10,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class GuiOpenChassie extends CoordinatesPacket {
 
 	public GuiOpenChassie(int id) {

--- a/common/logisticspipes/network/packets/gui/GuiReopenPacket.java
+++ b/common/logisticspipes/network/packets/gui/GuiReopenPacket.java
@@ -11,6 +11,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class GuiReopenPacket extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/gui/OpenChatGui.java
+++ b/common/logisticspipes/network/packets/gui/OpenChatGui.java
@@ -10,6 +10,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class OpenChatGui extends ModernPacket {
 
 	public OpenChatGui(int id) {

--- a/common/logisticspipes/network/packets/gui/OpenUpgradePacket.java
+++ b/common/logisticspipes/network/packets/gui/OpenUpgradePacket.java
@@ -9,6 +9,9 @@ import logisticspipes.pipes.upgrades.IConfigPipeUpgrade;
 import logisticspipes.pipes.upgrades.IPipeUpgrade;
 import logisticspipes.utils.gui.UpgradeSlot;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class OpenUpgradePacket extends SlotPacket {
 	public OpenUpgradePacket(int id) {
 		super(id);

--- a/common/logisticspipes/network/packets/hud/ChestContent.java
+++ b/common/logisticspipes/network/packets/hud/ChestContent.java
@@ -7,6 +7,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ChestContent extends InventoryModuleCoordinatesPacket {
 
 	public ChestContent(int id) {

--- a/common/logisticspipes/network/packets/hud/HUDSettingsPacket.java
+++ b/common/logisticspipes/network/packets/hud/HUDSettingsPacket.java
@@ -12,6 +12,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class HUDSettingsPacket extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/hud/HUDStartBlockWatchingPacket.java
+++ b/common/logisticspipes/network/packets/hud/HUDStartBlockWatchingPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class HUDStartBlockWatchingPacket extends CoordinatesPacket {
 
 	public HUDStartBlockWatchingPacket(int id) {

--- a/common/logisticspipes/network/packets/hud/HUDStartModuleWatchingPacket.java
+++ b/common/logisticspipes/network/packets/hud/HUDStartModuleWatchingPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class HUDStartModuleWatchingPacket extends ModuleCoordinatesPacket {
 
 	public HUDStartModuleWatchingPacket(int id) {

--- a/common/logisticspipes/network/packets/hud/HUDStartWatchingPacket.java
+++ b/common/logisticspipes/network/packets/hud/HUDStartWatchingPacket.java
@@ -7,6 +7,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class HUDStartWatchingPacket extends IntegerCoordinatesPacket {
 
 	public HUDStartWatchingPacket(int id) {

--- a/common/logisticspipes/network/packets/hud/HUDStopBlockWatchingPacket.java
+++ b/common/logisticspipes/network/packets/hud/HUDStopBlockWatchingPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class HUDStopBlockWatchingPacket extends CoordinatesPacket {
 
 	public HUDStopBlockWatchingPacket(int id) {

--- a/common/logisticspipes/network/packets/hud/HUDStopModuleWatchingPacket.java
+++ b/common/logisticspipes/network/packets/hud/HUDStopModuleWatchingPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class HUDStopModuleWatchingPacket extends ModuleCoordinatesPacket {
 
 	public HUDStopModuleWatchingPacket(int id) {

--- a/common/logisticspipes/network/packets/hud/HUDStopWatchingPacket.java
+++ b/common/logisticspipes/network/packets/hud/HUDStopWatchingPacket.java
@@ -7,6 +7,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class HUDStopWatchingPacket extends IntegerCoordinatesPacket {
 
 	public HUDStopWatchingPacket(int id) {

--- a/common/logisticspipes/network/packets/module/AdvancedExtractorIncludePacket.java
+++ b/common/logisticspipes/network/packets/module/AdvancedExtractorIncludePacket.java
@@ -9,6 +9,9 @@ import logisticspipes.proxy.MainProxy;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class AdvancedExtractorIncludePacket extends ModuleCoordinatesPacket {
 
 	public AdvancedExtractorIncludePacket(int id) {

--- a/common/logisticspipes/network/packets/module/AdvancedExtractorSneakyGuiPacket.java
+++ b/common/logisticspipes/network/packets/module/AdvancedExtractorSneakyGuiPacket.java
@@ -13,6 +13,9 @@ import logisticspipes.utils.gui.DummyModuleContainer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class AdvancedExtractorSneakyGuiPacket extends ModuleCoordinatesPacket {
 
 	public AdvancedExtractorSneakyGuiPacket(int id) {

--- a/common/logisticspipes/network/packets/module/ApiaristAnalyserMode.java
+++ b/common/logisticspipes/network/packets/module/ApiaristAnalyserMode.java
@@ -11,6 +11,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ApiaristAnalyserMode extends ModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/module/BeeModuleSetBeePacket.java
+++ b/common/logisticspipes/network/packets/module/BeeModuleSetBeePacket.java
@@ -12,6 +12,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class BeeModuleSetBeePacket extends ModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/module/ElectricManagerPacket.java
+++ b/common/logisticspipes/network/packets/module/ElectricManagerPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.modules.ModuleElectricManager;
 import logisticspipes.network.abstractpackets.BooleanModuleCoordinatesPacket;
 import logisticspipes.network.abstractpackets.ModernPacket;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ElectricManagerPacket extends BooleanModuleCoordinatesPacket {
 
 	public ElectricManagerPacket(int id) {

--- a/common/logisticspipes/network/packets/module/ElectricManagetMode.java
+++ b/common/logisticspipes/network/packets/module/ElectricManagetMode.java
@@ -6,6 +6,9 @@ import logisticspipes.modules.ModuleElectricManager;
 import logisticspipes.network.abstractpackets.BooleanModuleCoordinatesPacket;
 import logisticspipes.network.abstractpackets.ModernPacket;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ElectricManagetMode extends BooleanModuleCoordinatesPacket {
 
 	public ElectricManagetMode(int id) {

--- a/common/logisticspipes/network/packets/module/ExtractorModuleDirectionPacket.java
+++ b/common/logisticspipes/network/packets/module/ExtractorModuleDirectionPacket.java
@@ -9,6 +9,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import logisticspipes.network.packets.modules.ExtractorModuleMode;
 import logisticspipes.proxy.MainProxy;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ExtractorModuleDirectionPacket extends DirectionModuleCoordinatesPacket {
 
 	public ExtractorModuleDirectionPacket(int id) {

--- a/common/logisticspipes/network/packets/module/ItemSinkDefaultPacket.java
+++ b/common/logisticspipes/network/packets/module/ItemSinkDefaultPacket.java
@@ -11,6 +11,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ItemSinkDefaultPacket extends ModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/module/ItemSinkImportPacket.java
+++ b/common/logisticspipes/network/packets/module/ItemSinkImportPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.modules.ModuleItemSink;
 import logisticspipes.network.abstractpackets.ModernPacket;
 import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ItemSinkImportPacket extends ModuleCoordinatesPacket {
 
 	public ItemSinkImportPacket(int id) {

--- a/common/logisticspipes/network/packets/module/ModuleBasedItemSinkList.java
+++ b/common/logisticspipes/network/packets/module/ModuleBasedItemSinkList.java
@@ -13,6 +13,9 @@ import logisticspipes.proxy.MainProxy;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ModuleBasedItemSinkList extends ModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/module/ModuleInventory.java
+++ b/common/logisticspipes/network/packets/module/ModuleInventory.java
@@ -6,6 +6,9 @@ import logisticspipes.interfaces.IModuleInventoryReceive;
 import logisticspipes.network.abstractpackets.InventoryModuleCoordinatesPacket;
 import logisticspipes.network.abstractpackets.ModernPacket;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ModuleInventory extends InventoryModuleCoordinatesPacket {
 
 	public ModuleInventory(int id) {

--- a/common/logisticspipes/network/packets/module/OreDictItemSinkList.java
+++ b/common/logisticspipes/network/packets/module/OreDictItemSinkList.java
@@ -7,6 +7,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import logisticspipes.network.abstractpackets.NBTModuleCoordinatesPacket;
 import logisticspipes.proxy.MainProxy;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class OreDictItemSinkList extends NBTModuleCoordinatesPacket {
 
 	public OreDictItemSinkList(int id) {

--- a/common/logisticspipes/network/packets/module/ProviderModuleIncludePacket.java
+++ b/common/logisticspipes/network/packets/module/ProviderModuleIncludePacket.java
@@ -9,6 +9,9 @@ import logisticspipes.proxy.MainProxy;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ProviderModuleIncludePacket extends ModuleCoordinatesPacket {
 
 	public ProviderModuleIncludePacket(int id) {

--- a/common/logisticspipes/network/packets/module/ProviderModuleNextModePacket.java
+++ b/common/logisticspipes/network/packets/module/ProviderModuleNextModePacket.java
@@ -9,6 +9,9 @@ import logisticspipes.proxy.MainProxy;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ProviderModuleNextModePacket extends ModuleCoordinatesPacket {
 
 	public ProviderModuleNextModePacket(int id) {

--- a/common/logisticspipes/network/packets/module/ProviderPipeIncludePacket.java
+++ b/common/logisticspipes/network/packets/module/ProviderPipeIncludePacket.java
@@ -10,6 +10,9 @@ import logisticspipes.proxy.MainProxy;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ProviderPipeIncludePacket extends CoordinatesPacket {
 
 	public ProviderPipeIncludePacket(int id) {

--- a/common/logisticspipes/network/packets/module/ProviderPipeNextModePacket.java
+++ b/common/logisticspipes/network/packets/module/ProviderPipeNextModePacket.java
@@ -10,6 +10,9 @@ import logisticspipes.proxy.MainProxy;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ProviderPipeNextModePacket extends CoordinatesPacket {
 
 	public ProviderPipeNextModePacket(int id) {

--- a/common/logisticspipes/network/packets/module/SupplierPipeLimitedPacket.java
+++ b/common/logisticspipes/network/packets/module/SupplierPipeLimitedPacket.java
@@ -17,6 +17,9 @@ import logisticspipes.proxy.MainProxy;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SupplierPipeLimitedPacket extends ModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/module/SupplierPipeModePacket.java
+++ b/common/logisticspipes/network/packets/module/SupplierPipeModePacket.java
@@ -11,6 +11,9 @@ import logisticspipes.proxy.MainProxy;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SupplierPipeModePacket extends ModuleCoordinatesPacket {
 
 	public SupplierPipeModePacket(int id) {

--- a/common/logisticspipes/network/packets/modules/AdvancedExtractorInclude.java
+++ b/common/logisticspipes/network/packets/modules/AdvancedExtractorInclude.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class AdvancedExtractorInclude extends BooleanModuleCoordinatesPacket {
 
 	public AdvancedExtractorInclude(int id) {

--- a/common/logisticspipes/network/packets/modules/CCBasedQuickSortMode.java
+++ b/common/logisticspipes/network/packets/modules/CCBasedQuickSortMode.java
@@ -11,6 +11,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CCBasedQuickSortMode extends ModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/modules/CCBasedQuickSortSinkSize.java
+++ b/common/logisticspipes/network/packets/modules/CCBasedQuickSortSinkSize.java
@@ -11,6 +11,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CCBasedQuickSortSinkSize extends ModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/modules/CrafterDefault.java
+++ b/common/logisticspipes/network/packets/modules/CrafterDefault.java
@@ -9,6 +9,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CrafterDefault extends Integer2CoordinatesPacket {
 
 	public CrafterDefault(int id) {

--- a/common/logisticspipes/network/packets/modules/ExtractorModuleMode.java
+++ b/common/logisticspipes/network/packets/modules/ExtractorModuleMode.java
@@ -6,6 +6,9 @@ import logisticspipes.modules.abstractmodules.LogisticsSneakyDirectionModule;
 import logisticspipes.network.abstractpackets.DirectionModuleCoordinatesPacket;
 import logisticspipes.network.abstractpackets.ModernPacket;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ExtractorModuleMode extends DirectionModuleCoordinatesPacket {
 
 	public ExtractorModuleMode(int id) {

--- a/common/logisticspipes/network/packets/modules/ItemSinkDefault.java
+++ b/common/logisticspipes/network/packets/modules/ItemSinkDefault.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ItemSinkDefault extends BooleanModuleCoordinatesPacket {
 
 	public ItemSinkDefault(int id) {

--- a/common/logisticspipes/network/packets/modules/ItemSinkFuzzy.java
+++ b/common/logisticspipes/network/packets/modules/ItemSinkFuzzy.java
@@ -13,6 +13,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ItemSinkFuzzy extends ModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/modules/ProviderModuleInclude.java
+++ b/common/logisticspipes/network/packets/modules/ProviderModuleInclude.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ProviderModuleInclude extends BooleanModuleCoordinatesPacket {
 
 	public ProviderModuleInclude(int id) {

--- a/common/logisticspipes/network/packets/modules/ProviderModuleMode.java
+++ b/common/logisticspipes/network/packets/modules/ProviderModuleMode.java
@@ -11,6 +11,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ProviderModuleMode extends ModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/modules/ProviderPipeInclude.java
+++ b/common/logisticspipes/network/packets/modules/ProviderPipeInclude.java
@@ -10,6 +10,9 @@ import net.minecraft.entity.player.EntityPlayer;
 
 import net.minecraftforge.fml.client.FMLClientHandler;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ProviderPipeInclude extends IntegerCoordinatesPacket {
 
 	public ProviderPipeInclude(int id) {

--- a/common/logisticspipes/network/packets/modules/ProviderPipeMode.java
+++ b/common/logisticspipes/network/packets/modules/ProviderPipeMode.java
@@ -7,6 +7,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ProviderPipeMode extends IntegerCoordinatesPacket {
 
 	public ProviderPipeMode(int id) {

--- a/common/logisticspipes/network/packets/modules/QuickSortState.java
+++ b/common/logisticspipes/network/packets/modules/QuickSortState.java
@@ -6,6 +6,9 @@ import logisticspipes.utils.QuickSortChestMarkerStorage;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class QuickSortState extends Integer2CoordinatesPacket {
 
 	public QuickSortState(int id) {

--- a/common/logisticspipes/network/packets/modules/SupplierPipeMode.java
+++ b/common/logisticspipes/network/packets/modules/SupplierPipeMode.java
@@ -16,6 +16,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SupplierPipeMode extends IntegerModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/multiblock/MultiBlockCoordinatesPacket.java
+++ b/common/logisticspipes/network/packets/multiblock/MultiBlockCoordinatesPacket.java
@@ -16,6 +16,9 @@ import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 import network.rs485.logisticspipes.world.DoubleCoordinates;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class MultiBlockCoordinatesPacket extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/orderer/ComponentList.java
+++ b/common/logisticspipes/network/packets/orderer/ComponentList.java
@@ -22,6 +22,9 @@ import logisticspipes.request.resources.ResourceNetwork;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ComponentList extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/orderer/DiscContent.java
+++ b/common/logisticspipes/network/packets/orderer/DiscContent.java
@@ -10,6 +10,9 @@ import logisticspipes.proxy.MainProxy;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class DiscContent extends ItemPacket {
 
 	public DiscContent(int id) {

--- a/common/logisticspipes/network/packets/orderer/DiskDropPacket.java
+++ b/common/logisticspipes/network/packets/orderer/DiskDropPacket.java
@@ -11,6 +11,9 @@ import logisticspipes.proxy.MainProxy;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class DiskDropPacket extends CoordinatesPacket {
 
 	public DiskDropPacket(int id) {

--- a/common/logisticspipes/network/packets/orderer/DiskMacroRequestPacket.java
+++ b/common/logisticspipes/network/packets/orderer/DiskMacroRequestPacket.java
@@ -12,6 +12,9 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class DiskMacroRequestPacket extends IntegerCoordinatesPacket {
 
 	public DiskMacroRequestPacket(int id) {

--- a/common/logisticspipes/network/packets/orderer/DiskRequestConectPacket.java
+++ b/common/logisticspipes/network/packets/orderer/DiskRequestConectPacket.java
@@ -12,6 +12,9 @@ import logisticspipes.proxy.MainProxy;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class DiskRequestConectPacket extends CoordinatesPacket {
 
 	public DiskRequestConectPacket(int id) {

--- a/common/logisticspipes/network/packets/orderer/DiskSetNamePacket.java
+++ b/common/logisticspipes/network/packets/orderer/DiskSetNamePacket.java
@@ -9,6 +9,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class DiskSetNamePacket extends StringCoordinatesPacket {
 
 	public DiskSetNamePacket(int id) {

--- a/common/logisticspipes/network/packets/orderer/MissingItems.java
+++ b/common/logisticspipes/network/packets/orderer/MissingItems.java
@@ -23,6 +23,9 @@ import logisticspipes.utils.string.ChatColor;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class MissingItems extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/orderer/OrderWatchRemovePacket.java
+++ b/common/logisticspipes/network/packets/orderer/OrderWatchRemovePacket.java
@@ -7,6 +7,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class OrderWatchRemovePacket extends IntegerCoordinatesPacket {
 
 	public OrderWatchRemovePacket(int id) {

--- a/common/logisticspipes/network/packets/orderer/OrdererContent.java
+++ b/common/logisticspipes/network/packets/orderer/OrdererContent.java
@@ -9,6 +9,9 @@ import net.minecraft.entity.player.EntityPlayer;
 
 import net.minecraftforge.fml.client.FMLClientHandler;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class OrdererContent extends InventoryModuleCoordinatesPacket {
 
 	public OrdererContent(int id) {

--- a/common/logisticspipes/network/packets/orderer/OrdererManagerContent.java
+++ b/common/logisticspipes/network/packets/orderer/OrdererManagerContent.java
@@ -7,6 +7,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class OrdererManagerContent extends InventoryModuleCoordinatesPacket {
 
 	public OrdererManagerContent(int id) {

--- a/common/logisticspipes/network/packets/orderer/OrdererRefreshRequestPacket.java
+++ b/common/logisticspipes/network/packets/orderer/OrdererRefreshRequestPacket.java
@@ -9,6 +9,9 @@ import logisticspipes.request.RequestHandler;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class OrdererRefreshRequestPacket extends IntegerCoordinatesPacket {
 
 	public OrdererRefreshRequestPacket(int id) {

--- a/common/logisticspipes/network/packets/orderer/OrdererWatchPacket.java
+++ b/common/logisticspipes/network/packets/orderer/OrdererWatchPacket.java
@@ -15,6 +15,9 @@ import logisticspipes.routing.order.LinkedLogisticsOrderList;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class OrdererWatchPacket extends IntegerCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/orderer/RequestComponentPacket.java
+++ b/common/logisticspipes/network/packets/orderer/RequestComponentPacket.java
@@ -9,6 +9,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import logisticspipes.proxy.MainProxy;
 import logisticspipes.request.RequestHandler;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RequestComponentPacket extends RequestPacket {
 
 	public RequestComponentPacket(int id) {

--- a/common/logisticspipes/network/packets/orderer/RequestFluidOrdererRefreshPacket.java
+++ b/common/logisticspipes/network/packets/orderer/RequestFluidOrdererRefreshPacket.java
@@ -9,6 +9,9 @@ import logisticspipes.request.RequestHandler;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RequestFluidOrdererRefreshPacket extends IntegerCoordinatesPacket {
 
 	public RequestFluidOrdererRefreshPacket(int id) {

--- a/common/logisticspipes/network/packets/orderer/RequestSubmitListPacket.java
+++ b/common/logisticspipes/network/packets/orderer/RequestSubmitListPacket.java
@@ -9,6 +9,9 @@ import logisticspipes.request.RequestHandler;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RequestSubmitListPacket extends InventoryModuleCoordinatesPacket {
 
 	public RequestSubmitListPacket(int id) {

--- a/common/logisticspipes/network/packets/orderer/RequestSubmitPacket.java
+++ b/common/logisticspipes/network/packets/orderer/RequestSubmitPacket.java
@@ -9,6 +9,9 @@ import logisticspipes.request.RequestHandler;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RequestSubmitPacket extends RequestPacket {
 
 	public RequestSubmitPacket(int id) {

--- a/common/logisticspipes/network/packets/orderer/SubmitFluidRequestPacket.java
+++ b/common/logisticspipes/network/packets/orderer/SubmitFluidRequestPacket.java
@@ -10,6 +10,9 @@ import logisticspipes.request.RequestHandler;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SubmitFluidRequestPacket extends RequestPacket {
 
 	public SubmitFluidRequestPacket(int id) {

--- a/common/logisticspipes/network/packets/pipe/AskForOpenTarget.java
+++ b/common/logisticspipes/network/packets/pipe/AskForOpenTarget.java
@@ -11,6 +11,9 @@ import logisticspipes.proxy.MainProxy;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class AskForOpenTarget extends ModernPacket {
 
 	public AskForOpenTarget(int id) {

--- a/common/logisticspipes/network/packets/pipe/ChassiOrientationPacket.java
+++ b/common/logisticspipes/network/packets/pipe/ChassiOrientationPacket.java
@@ -11,6 +11,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import logisticspipes.pipes.PipeLogisticsChassi;
 import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ChassiOrientationPacket extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/pipe/ChassiePipeModuleContent.java
+++ b/common/logisticspipes/network/packets/pipe/ChassiePipeModuleContent.java
@@ -7,6 +7,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ChassiePipeModuleContent extends InventoryModuleCoordinatesPacket {
 
 	public ChassiePipeModuleContent(int id) {

--- a/common/logisticspipes/network/packets/pipe/CraftingPipePriorityDownPacket.java
+++ b/common/logisticspipes/network/packets/pipe/CraftingPipePriorityDownPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CraftingPipePriorityDownPacket extends ModuleCoordinatesPacket {
 
 	public CraftingPipePriorityDownPacket(int id) {

--- a/common/logisticspipes/network/packets/pipe/CraftingPipePriorityUpPacket.java
+++ b/common/logisticspipes/network/packets/pipe/CraftingPipePriorityUpPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CraftingPipePriorityUpPacket extends ModuleCoordinatesPacket {
 
 	public CraftingPipePriorityUpPacket(int id) {

--- a/common/logisticspipes/network/packets/pipe/CraftingPipeUpdatePacket.java
+++ b/common/logisticspipes/network/packets/pipe/CraftingPipeUpdatePacket.java
@@ -12,6 +12,9 @@ import logisticspipes.network.abstractpackets.ModuleCoordinatesPacket;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CraftingPipeUpdatePacket extends ModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/pipe/CraftingPriority.java
+++ b/common/logisticspipes/network/packets/pipe/CraftingPriority.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class CraftingPriority extends IntegerModuleCoordinatesPacket {
 
 	public CraftingPriority(int id) {

--- a/common/logisticspipes/network/packets/pipe/FindMostLikelyRecipeComponents.java
+++ b/common/logisticspipes/network/packets/pipe/FindMostLikelyRecipeComponents.java
@@ -28,6 +28,9 @@ import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 import network.rs485.logisticspipes.world.CoordinateUtils;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class FindMostLikelyRecipeComponents extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/pipe/FireWallFlag.java
+++ b/common/logisticspipes/network/packets/pipe/FireWallFlag.java
@@ -7,6 +7,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 import logisticspipes.pipes.PipeItemsFirewall;
 import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class FireWallFlag extends BitSetCoordinatesPacket {
 
 	public FireWallFlag(int id) {

--- a/common/logisticspipes/network/packets/pipe/FluidCraftingAdvancedSatelliteId.java
+++ b/common/logisticspipes/network/packets/pipe/FluidCraftingAdvancedSatelliteId.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class FluidCraftingAdvancedSatelliteId extends Integer2ModuleCoordinatesPacket {
 
 	public FluidCraftingAdvancedSatelliteId(int id) {

--- a/common/logisticspipes/network/packets/pipe/FluidCraftingAmount.java
+++ b/common/logisticspipes/network/packets/pipe/FluidCraftingAmount.java
@@ -7,6 +7,9 @@ import logisticspipes.network.abstractpackets.Integer2ModuleCoordinatesPacket;
 import logisticspipes.network.abstractpackets.ModernPacket;
 import logisticspipes.proxy.MainProxy;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class FluidCraftingAmount extends Integer2ModuleCoordinatesPacket {
 
 	public FluidCraftingAmount(int id) {

--- a/common/logisticspipes/network/packets/pipe/FluidCraftingPipeAdvancedSatelliteNextPacket.java
+++ b/common/logisticspipes/network/packets/pipe/FluidCraftingPipeAdvancedSatelliteNextPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class FluidCraftingPipeAdvancedSatelliteNextPacket extends IntegerModuleCoordinatesPacket {
 
 	public FluidCraftingPipeAdvancedSatelliteNextPacket(int id) {

--- a/common/logisticspipes/network/packets/pipe/FluidCraftingPipeAdvancedSatellitePrevPacket.java
+++ b/common/logisticspipes/network/packets/pipe/FluidCraftingPipeAdvancedSatellitePrevPacket.java
@@ -6,6 +6,9 @@ import logisticspipes.network.abstractpackets.ModernPacket;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class FluidCraftingPipeAdvancedSatellitePrevPacket extends IntegerModuleCoordinatesPacket {
 
 	public FluidCraftingPipeAdvancedSatellitePrevPacket(int id) {

--- a/common/logisticspipes/network/packets/pipe/FluidSupplierAmount.java
+++ b/common/logisticspipes/network/packets/pipe/FluidSupplierAmount.java
@@ -8,6 +8,9 @@ import logisticspipes.pipes.PipeFluidSupplierMk2;
 import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import logisticspipes.proxy.MainProxy;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class FluidSupplierAmount extends IntegerCoordinatesPacket {
 
 	public FluidSupplierAmount(int id) {

--- a/common/logisticspipes/network/packets/pipe/FluidSupplierMinMode.java
+++ b/common/logisticspipes/network/packets/pipe/FluidSupplierMinMode.java
@@ -8,6 +8,9 @@ import logisticspipes.pipes.PipeFluidSupplierMk2;
 import logisticspipes.pipes.PipeFluidSupplierMk2.MinMode;
 import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class FluidSupplierMinMode extends IntegerCoordinatesPacket {
 
 	public FluidSupplierMinMode(int id) {

--- a/common/logisticspipes/network/packets/pipe/FluidSupplierMode.java
+++ b/common/logisticspipes/network/packets/pipe/FluidSupplierMode.java
@@ -9,6 +9,9 @@ import logisticspipes.pipes.PipeItemsFluidSupplier;
 import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import logisticspipes.proxy.MainProxy;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class FluidSupplierMode extends IntegerCoordinatesPacket {
 
 	public FluidSupplierMode(int id) {

--- a/common/logisticspipes/network/packets/pipe/InvSysConContent.java
+++ b/common/logisticspipes/network/packets/pipe/InvSysConContent.java
@@ -8,6 +8,9 @@ import net.minecraft.entity.player.EntityPlayer;
 
 import net.minecraftforge.fml.client.FMLClientHandler;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class InvSysConContent extends InventoryModuleCoordinatesPacket {
 
 	public InvSysConContent(int id) {

--- a/common/logisticspipes/network/packets/pipe/InvSysConContentRequest.java
+++ b/common/logisticspipes/network/packets/pipe/InvSysConContentRequest.java
@@ -9,6 +9,9 @@ import logisticspipes.proxy.MainProxy;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class InvSysConContentRequest extends CoordinatesPacket {
 
 	public InvSysConContentRequest(int id) {

--- a/common/logisticspipes/network/packets/pipe/InvSysConResistance.java
+++ b/common/logisticspipes/network/packets/pipe/InvSysConResistance.java
@@ -8,6 +8,9 @@ import logisticspipes.pipes.PipeItemsInvSysConnector;
 import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import logisticspipes.proxy.MainProxy;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class InvSysConResistance extends IntegerCoordinatesPacket {
 
 	public InvSysConResistance(int id) {

--- a/common/logisticspipes/network/packets/pipe/ItemAmountSignUpdatePacket.java
+++ b/common/logisticspipes/network/packets/pipe/ItemAmountSignUpdatePacket.java
@@ -16,6 +16,9 @@ import logisticspipes.utils.item.ItemIdentifierStack;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ItemAmountSignUpdatePacket extends Integer2CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/pipe/ItemBufferSyncPacket.java
+++ b/common/logisticspipes/network/packets/pipe/ItemBufferSyncPacket.java
@@ -1,5 +1,6 @@
 package logisticspipes.network.packets.pipe;
 
+import logisticspipes.utils.StaticResolve;
 import net.minecraft.entity.player.EntityPlayer;
 
 import logisticspipes.network.abstractpackets.ListSyncPacket;
@@ -11,6 +12,7 @@ import logisticspipes.utils.tuples.Triplet;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+@StaticResolve
 public class ItemBufferSyncPacket
 		extends ListSyncPacket<Triplet<ItemIdentifierStack, Pair<Integer /* Time */, Integer /* BufferCounter */>, LPTravelingItemServer>> {
 

--- a/common/logisticspipes/network/packets/pipe/MostLikelyRecipeComponentsResponse.java
+++ b/common/logisticspipes/network/packets/pipe/MostLikelyRecipeComponentsResponse.java
@@ -19,6 +19,9 @@ import logisticspipes.utils.gui.SubGuiScreen;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class MostLikelyRecipeComponentsResponse extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/pipe/ParticleFX.java
+++ b/common/logisticspipes/network/packets/pipe/ParticleFX.java
@@ -18,6 +18,9 @@ import logisticspipes.pipefxhandlers.PipeFXRenderHandler;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ParticleFX extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/pipe/PipeContentPacket.java
+++ b/common/logisticspipes/network/packets/pipe/PipeContentPacket.java
@@ -15,6 +15,9 @@ import logisticspipes.utils.tuples.Pair;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PipeContentPacket extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/pipe/PipeContentRequest.java
+++ b/common/logisticspipes/network/packets/pipe/PipeContentRequest.java
@@ -11,6 +11,9 @@ import logisticspipes.transport.LPTravelingItem.LPTravelingItemServer;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PipeContentRequest extends IntegerPacket {
 
 	public PipeContentRequest(int id) {

--- a/common/logisticspipes/network/packets/pipe/PipeDebugAskForTarget.java
+++ b/common/logisticspipes/network/packets/pipe/PipeDebugAskForTarget.java
@@ -18,6 +18,9 @@ import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 import network.rs485.logisticspipes.world.DoubleCoordinates;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PipeDebugAskForTarget extends ModernPacket {
 
 	@Setter

--- a/common/logisticspipes/network/packets/pipe/PipeDebugResponse.java
+++ b/common/logisticspipes/network/packets/pipe/PipeDebugResponse.java
@@ -7,6 +7,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.text.TextComponentString;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PipeDebugResponse extends CoordinatesPacket {
 
 	public PipeDebugResponse(int id) {

--- a/common/logisticspipes/network/packets/pipe/PipeFluidUpdate.java
+++ b/common/logisticspipes/network/packets/pipe/PipeFluidUpdate.java
@@ -19,6 +19,9 @@ import logisticspipes.transport.PipeFluidTransportLogistics;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PipeFluidUpdate extends CoordinatesPacket {
 
 	@Getter(value = AccessLevel.PRIVATE)

--- a/common/logisticspipes/network/packets/pipe/PipeManagerContentPacket.java
+++ b/common/logisticspipes/network/packets/pipe/PipeManagerContentPacket.java
@@ -18,6 +18,9 @@ import logisticspipes.routing.order.LogisticsOrderManager;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PipeManagerContentPacket extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/pipe/PipeManagerWatchingPacket.java
+++ b/common/logisticspipes/network/packets/pipe/PipeManagerWatchingPacket.java
@@ -12,6 +12,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PipeManagerWatchingPacket extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/pipe/PipePositionPacket.java
+++ b/common/logisticspipes/network/packets/pipe/PipePositionPacket.java
@@ -12,6 +12,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PipePositionPacket extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/pipe/PipeSignTypes.java
+++ b/common/logisticspipes/network/packets/pipe/PipeSignTypes.java
@@ -14,6 +14,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PipeSignTypes extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/pipe/PipeTileStatePacket.java
+++ b/common/logisticspipes/network/packets/pipe/PipeTileStatePacket.java
@@ -13,6 +13,9 @@ import network.rs485.logisticspipes.util.LPDataIOWrapper;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class PipeTileStatePacket extends CoordinatesPacket {
 
 	@Setter

--- a/common/logisticspipes/network/packets/pipe/RequestChassiOrientationPacket.java
+++ b/common/logisticspipes/network/packets/pipe/RequestChassiOrientationPacket.java
@@ -9,6 +9,9 @@ import logisticspipes.proxy.MainProxy;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RequestChassiOrientationPacket extends CoordinatesPacket {
 
 	public RequestChassiOrientationPacket(int id) {

--- a/common/logisticspipes/network/packets/pipe/RequestPipeDimension.java
+++ b/common/logisticspipes/network/packets/pipe/RequestPipeDimension.java
@@ -8,6 +8,9 @@ import net.minecraft.entity.player.EntityPlayer;
 
 import net.minecraftforge.fml.client.FMLClientHandler;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RequestPipeDimension extends IntegerPacket {
 
 	public RequestPipeDimension(int id) {

--- a/common/logisticspipes/network/packets/pipe/RequestRoutingLasersPacket.java
+++ b/common/logisticspipes/network/packets/pipe/RequestRoutingLasersPacket.java
@@ -18,24 +18,24 @@ import logisticspipes.pipes.basic.CoreRoutedPipe;
 import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import logisticspipes.proxy.MainProxy;
 import logisticspipes.routing.ExitRoute;
-import logisticspipes.routing.IPaintPath;
 import logisticspipes.routing.IRouter;
 import logisticspipes.routing.LaserData;
 import logisticspipes.routing.PipeRoutingConnectionType;
 import logisticspipes.routing.pathfinder.PathFinder;
 
 import network.rs485.logisticspipes.world.CoordinateUtils;
-import network.rs485.logisticspipes.world.DoubleCoordinates;
 import network.rs485.logisticspipes.world.IntegerCoordinates;
 
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.world.World;
 
 import net.minecraft.util.EnumFacing;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RequestRoutingLasersPacket extends CoordinatesPacket {
 
 	private abstract class Log {

--- a/common/logisticspipes/network/packets/pipe/RequestSignPacket.java
+++ b/common/logisticspipes/network/packets/pipe/RequestSignPacket.java
@@ -7,6 +7,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RequestSignPacket extends CoordinatesPacket {
 
 	public RequestSignPacket(int id) {

--- a/common/logisticspipes/network/packets/pipe/RoutingLaserPacket.java
+++ b/common/logisticspipes/network/packets/pipe/RoutingLaserPacket.java
@@ -14,6 +14,9 @@ import logisticspipes.routing.LaserData;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RoutingLaserPacket extends ModernPacket {
 
 	@Setter

--- a/common/logisticspipes/network/packets/pipe/SendQueueContent.java
+++ b/common/logisticspipes/network/packets/pipe/SendQueueContent.java
@@ -7,6 +7,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SendQueueContent extends InventoryModuleCoordinatesPacket {
 
 	public SendQueueContent(int id) {

--- a/common/logisticspipes/network/packets/pipe/SlotFinderActivatePacket.java
+++ b/common/logisticspipes/network/packets/pipe/SlotFinderActivatePacket.java
@@ -11,6 +11,9 @@ import logisticspipes.renderer.LogisticsGuiOverrenderer;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SlotFinderActivatePacket extends ModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/pipe/SlotFinderNumberPacket.java
+++ b/common/logisticspipes/network/packets/pipe/SlotFinderNumberPacket.java
@@ -1,11 +1,7 @@
 package logisticspipes.network.packets.pipe;
 
-import java.util.List;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
-import net.minecraft.inventory.IInventory;
-import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -26,6 +22,9 @@ import logisticspipes.utils.item.ItemIdentifier;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SlotFinderNumberPacket extends ModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/pipe/SlotFinderOpenGuiPacket.java
+++ b/common/logisticspipes/network/packets/pipe/SlotFinderOpenGuiPacket.java
@@ -9,7 +9,6 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
-import net.minecraft.util.math.BlockPos;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -25,10 +24,12 @@ import logisticspipes.routing.pathfinder.IPipeInformationProvider.ConnectionPipe
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 import network.rs485.logisticspipes.world.DoubleCoordinates;
-import network.rs485.logisticspipes.world.IntegerCoordinates;
 import network.rs485.logisticspipes.world.WorldCoordinatesWrapper;
 import network.rs485.logisticspipes.world.WorldCoordinatesWrapper.AdjacentTileEntity;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SlotFinderOpenGuiPacket extends ModuleCoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/pipe/StatUpdate.java
+++ b/common/logisticspipes/network/packets/pipe/StatUpdate.java
@@ -14,6 +14,9 @@ import logisticspipes.routing.ExitRoute;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class StatUpdate extends CoordinatesPacket {
 
 	@Setter

--- a/common/logisticspipes/network/packets/routingdebug/RoutingUpdateAskForTarget.java
+++ b/common/logisticspipes/network/packets/routingdebug/RoutingUpdateAskForTarget.java
@@ -13,6 +13,9 @@ import logisticspipes.proxy.MainProxy;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RoutingUpdateAskForTarget extends ModernPacket {
 
 	public RoutingUpdateAskForTarget(int id) {

--- a/common/logisticspipes/network/packets/routingdebug/RoutingUpdateCanidatePipe.java
+++ b/common/logisticspipes/network/packets/routingdebug/RoutingUpdateCanidatePipe.java
@@ -11,6 +11,9 @@ import logisticspipes.routing.debug.ClientViewController;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RoutingUpdateCanidatePipe extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/routingdebug/RoutingUpdateClearClient.java
+++ b/common/logisticspipes/network/packets/routingdebug/RoutingUpdateClearClient.java
@@ -7,6 +7,9 @@ import logisticspipes.routing.debug.ClientViewController;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RoutingUpdateClearClient extends ModernPacket {
 
 	public RoutingUpdateClearClient(int id) {

--- a/common/logisticspipes/network/packets/routingdebug/RoutingUpdateDebugCanidateList.java
+++ b/common/logisticspipes/network/packets/routingdebug/RoutingUpdateDebugCanidateList.java
@@ -11,6 +11,9 @@ import logisticspipes.routing.debug.ClientViewController;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RoutingUpdateDebugCanidateList extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/routingdebug/RoutingUpdateDebugClosedSet.java
+++ b/common/logisticspipes/network/packets/routingdebug/RoutingUpdateDebugClosedSet.java
@@ -14,6 +14,9 @@ import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 import network.rs485.logisticspipes.world.DoubleCoordinates;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RoutingUpdateDebugClosedSet extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/routingdebug/RoutingUpdateDebugFilters.java
+++ b/common/logisticspipes/network/packets/routingdebug/RoutingUpdateDebugFilters.java
@@ -17,6 +17,9 @@ import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 import network.rs485.logisticspipes.world.DoubleCoordinates;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RoutingUpdateDebugFilters extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/routingdebug/RoutingUpdateDoneDebug.java
+++ b/common/logisticspipes/network/packets/routingdebug/RoutingUpdateDoneDebug.java
@@ -7,6 +7,9 @@ import logisticspipes.routing.debug.ClientViewController;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RoutingUpdateDoneDebug extends ModernPacket {
 
 	public RoutingUpdateDoneDebug(int id) {

--- a/common/logisticspipes/network/packets/routingdebug/RoutingUpdateInitDebug.java
+++ b/common/logisticspipes/network/packets/routingdebug/RoutingUpdateInitDebug.java
@@ -7,6 +7,9 @@ import logisticspipes.routing.debug.ClientViewController;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RoutingUpdateInitDebug extends ModernPacket {
 
 	public RoutingUpdateInitDebug(int id) {

--- a/common/logisticspipes/network/packets/routingdebug/RoutingUpdateSourcePipe.java
+++ b/common/logisticspipes/network/packets/routingdebug/RoutingUpdateSourcePipe.java
@@ -11,6 +11,9 @@ import logisticspipes.routing.debug.ClientViewController;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RoutingUpdateSourcePipe extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/routingdebug/RoutingUpdateTargetResponse.java
+++ b/common/logisticspipes/network/packets/routingdebug/RoutingUpdateTargetResponse.java
@@ -22,6 +22,9 @@ import logisticspipes.utils.string.ChatColor;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RoutingUpdateTargetResponse extends ModernPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/routingdebug/RoutingUpdateUntrace.java
+++ b/common/logisticspipes/network/packets/routingdebug/RoutingUpdateUntrace.java
@@ -6,6 +6,9 @@ import logisticspipes.routing.debug.DebugController;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class RoutingUpdateUntrace extends IntegerPacket {
 
 	public RoutingUpdateUntrace(int id) {

--- a/common/logisticspipes/network/packets/satpipe/SatPipeNext.java
+++ b/common/logisticspipes/network/packets/satpipe/SatPipeNext.java
@@ -8,6 +8,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SatPipeNext extends CoordinatesPacket {
 
 	public SatPipeNext(int id) {

--- a/common/logisticspipes/network/packets/satpipe/SatPipePrev.java
+++ b/common/logisticspipes/network/packets/satpipe/SatPipePrev.java
@@ -8,6 +8,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SatPipePrev extends CoordinatesPacket {
 
 	public SatPipePrev(int id) {

--- a/common/logisticspipes/network/packets/satpipe/SatPipeSetID.java
+++ b/common/logisticspipes/network/packets/satpipe/SatPipeSetID.java
@@ -13,6 +13,9 @@ import logisticspipes.pipes.basic.LogisticsTileGenericPipe;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SatPipeSetID extends CoordinatesPacket {
 
 	@Getter

--- a/common/logisticspipes/network/packets/upgrade/SneakyUpgradeSidePacket.java
+++ b/common/logisticspipes/network/packets/upgrade/SneakyUpgradeSidePacket.java
@@ -15,6 +15,9 @@ import logisticspipes.utils.gui.UpgradeSlot;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class SneakyUpgradeSidePacket extends SlotPacket {
 
 	@Setter

--- a/common/logisticspipes/network/packets/upgrade/ToogleDisconnectionUpgradeSidePacket.java
+++ b/common/logisticspipes/network/packets/upgrade/ToogleDisconnectionUpgradeSidePacket.java
@@ -15,6 +15,9 @@ import logisticspipes.utils.gui.UpgradeSlot;
 import network.rs485.logisticspipes.util.LPDataInput;
 import network.rs485.logisticspipes.util.LPDataOutput;
 
+import logisticspipes.utils.StaticResolve;
+
+@StaticResolve
 public class ToogleDisconnectionUpgradeSidePacket extends SlotPacket {
 
 	@Getter

--- a/common/logisticspipes/utils/StaticResolve.java
+++ b/common/logisticspipes/utils/StaticResolve.java
@@ -1,0 +1,6 @@
+package logisticspipes.utils;
+
+/**
+ * Annotation for stuff that needs to be statically registered
+ */
+public @interface StaticResolve {}

--- a/common/logisticspipes/utils/StaticResolverUtil.java
+++ b/common/logisticspipes/utils/StaticResolverUtil.java
@@ -5,7 +5,12 @@ import net.minecraftforge.fml.common.discovery.ASMDataTable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class StaticResolverUtil {

--- a/common/logisticspipes/utils/StaticResolverUtil.java
+++ b/common/logisticspipes/utils/StaticResolverUtil.java
@@ -1,0 +1,47 @@
+package logisticspipes.utils;
+
+import logisticspipes.LogisticsPipes;
+import net.minecraftforge.fml.common.discovery.ASMDataTable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class StaticResolverUtil {
+
+	private static Set<ASMDataTable.ASMData> data = new HashSet<>();
+	private static Map<Class<?>, Set<Class<?>>> classes = new HashMap<>();
+
+	public static void useASMDataTable(@Nullable ASMDataTable table) {
+		data.clear();
+		classes.clear();
+		if (table == null) return;
+		data.addAll(table.getAll(StaticResolve.class.getCanonicalName()));
+	}
+
+	@Nonnull
+	public static <T> Set<Class<? extends T>> findClassesByType(@Nonnull Class<T> cls) {
+		if (data.isEmpty()) return Collections.emptySet();
+
+		Set<Class<?>> classes = StaticResolverUtil.classes.computeIfAbsent(cls, c ->
+				data.parallelStream()
+						.map(d -> loadClass(d.getClassName()))
+						.filter(Objects::nonNull)
+						.filter(cls::isAssignableFrom)
+						.collect(Collectors.toSet())
+		);
+		return (Set<Class<? extends T>>) (Set<?>) classes;
+	}
+
+	@Nullable
+	private static Class<?> loadClass(@Nonnull String classPathSpec) {
+		try {
+			return LogisticsPipes.class.getClassLoader().loadClass(classPathSpec);
+		} catch (ClassNotFoundException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+}


### PR DESCRIPTION
Now it doesn't have to go through the file system to figure out which packets and guis to load, but instead uses Forge's ASMData system. This should never have any cases where it won't load, so any kind of fallback (that also has a chance of not working) isn't necessary. Downside is, all classes that should be loaded must be annotated with `@StaticResolve` (I automated this for all existing classes with `sed`, but when creating a new class you don't have to do that, of course).

This moves the packet and gui init code from the constructor to preInit because that's the place where you get the ASMData, which shouldn't affect anything as far as I could see (and a quick test confirmed that, also that the same classes were loaded as before).