### PR TITLE
Move mod dependency info to mcmod.info, again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,8 @@ minecraft {
     version = "1.12.2-14.23.4.2705"
     runDir = "run/assets"
     replace '%VERSION%', project.version
-    replace '%MCVERSION%', "1.12.2"
+    replace '%MCVERSION%', project.minecraft.version
     replace '%DEBUG%', "false"
-    replaceIn "LogisticsPipes.java"
     replaceIn "LPConstants.java"
     mappings = "snapshot_20171120"
 }

--- a/common/logisticspipes/LogisticsPipes.java
+++ b/common/logisticspipes/LogisticsPipes.java
@@ -194,23 +194,8 @@ import network.rs485.grow.TickExecutor;
 
 @Mod(
 		modid = LPConstants.LP_MOD_ID,
-		name = "Logistics Pipes",
-		version = "%VERSION%",
 		/* %------------CERTIFICATE-SUM-----------% */
-		dependencies = "required-after:forge@[10.12.1.1079,);" +
-				"required-after:codechickenlib;" +
-				"after:buildcraft|Core;" +
-				"after:buildcraft|Transport;" +
-				"after:buildcraft|Silicon;" +
-				"after:buildcraft|Robotics;" +
-				"after:ic2;" +
-				"after:forestry;" +
-				"after:computercraft;" +
-				"after:factorization;" +
-				"after:gregtech_addon;" +
-				"after:appliedenergistics;" +
-				"after:thermalexpansion;" +
-		"after:BetterStorage")
+		useMetadata = true)
 public class LogisticsPipes {
 
 	//@formatter:on

--- a/resources/mcmod.info
+++ b/resources/mcmod.info
@@ -30,5 +30,6 @@
         "thermalexpansion",
         "betterstorage"
     ],
-    "dependants": []
+    "dependants": [],
+    "useDependencyInformation": true
 }]


### PR DESCRIPTION
This time properly tested without CodeChickenLib and this time it complains about that missing. TIL, I guess…

(For reference: both useDependencyInformation in mcmod.info and useMetadata in `@Mod` need to be set to true for this to work.)