### PR TITLE
Update remote order receipt to be unique from Pipe Controller (fixes #1165)

### DIFF
--- a/resources/assets/logisticspipes/recipes/remote_orderer.json
+++ b/resources/assets/logisticspipes/recipes/remote_orderer.json
@@ -2,8 +2,8 @@
   "type": "minecraft:crafting_shaped",
   "pattern": [
     "gbg",
-    "rsl",
-    "rrl"
+    "lsl",
+    "rrr"
   ],
   "key": {
     "b": {


### PR DESCRIPTION
Swapped the redstone and lapis, checked and this is a unique recipe for LP. Keeps material cost the same.