### PR TITLE
Fixed add "G" case to item stack size. #1178

### DIFF
--- a/common/logisticspipes/utils/string/StringUtils.java
+++ b/common/logisticspipes/utils/string/StringUtils.java
@@ -110,10 +110,12 @@ public final class StringUtils {
 			s = stackSize + "";
 		} else if (stackSize < 100000) {
 			s = stackSize / 1000 + "K";
-		} else if (stackSize < 1000000) {
-			s = "0M" + stackSize / 100000;
-		} else {
+		} else if (stackSize < 10000000) {
+			s = (int)stackSize / 1000000 + "M" + (stackSize - ((int)stackSize / 1000000) * 1000000) / 100000;
+		} else if (stackSize < 100000000) {
 			s = stackSize / 1000000 + "M";
+		} else {
+			s = (int)stackSize / 1000000000 + "G" + (stackSize - ((int)stackSize / 1000000000) * 1000000000) / 100000000;
 		}
 		return s;
 	}


### PR DESCRIPTION
Added 'G' prefix to the number of items shown in a request pipe's GUI. It goes like:
0 - 999
1K - 99K
0M1 - 9M9
10M - 99M
0G1 - 2G1