### PR TITLE
skip empty slots in quick sort don't try to route empty items.

### DIFF
--- a/common/logisticspipes/modules/ModuleQuickSort.java
+++ b/common/logisticspipes/modules/ModuleQuickSort.java
@@ -164,7 +164,7 @@ public class ModuleQuickSort extends LogisticsGuiModule {
 
 			ItemStack slot = invUtil.getStackInSlot(lastStackLookedAt);
 
-			while (slot == null) {
+			while (slot == null || slot.isEmpty()) {
 				lastStackLookedAt++;
 				if (lastStackLookedAt >= invUtil.getSizeInventory()) {
 					lastStackLookedAt = 0;

--- a/common/logisticspipes/modules/ModuleQuickSort.java
+++ b/common/logisticspipes/modules/ModuleQuickSort.java
@@ -164,7 +164,7 @@ public class ModuleQuickSort extends LogisticsGuiModule {
 
 			ItemStack slot = invUtil.getStackInSlot(lastStackLookedAt);
 
-			while (slot == null || slot.isEmpty()) {
+			while (slot.isEmpty()) {
 				lastStackLookedAt++;
 				if (lastStackLookedAt >= invUtil.getSizeInventory()) {
 					lastStackLookedAt = 0;


### PR DESCRIPTION
posible fix for #1261 