### PR TITLE
Fix crash with FinalNBTTagCompound

### DIFF
--- a/common/logisticspipes/utils/FinalNBTTagCompound.java
+++ b/common/logisticspipes/utils/FinalNBTTagCompound.java
@@ -11,7 +11,9 @@ import net.minecraft.nbt.NBTTagCompound;
 public class FinalNBTTagCompound extends NBTTagCompound {
 
 	public FinalNBTTagCompound(NBTTagCompound base) {
-		super.merge(base);
+		super();
+		NBTTagCompound copy = base.copy();
+		tagMap.putAll(copy.tagMap);
 	}
 
 	@Nonnull

--- a/common/logisticspipes/utils/FinalNBTTagCompound.java
+++ b/common/logisticspipes/utils/FinalNBTTagCompound.java
@@ -9,7 +9,9 @@ import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 
 public class FinalNBTTagCompound extends NBTTagCompound {
+
 	private boolean constructing;
+
 	public FinalNBTTagCompound(NBTTagCompound base) {
 		super();
 		constructing = true;
@@ -25,85 +27,85 @@ public class FinalNBTTagCompound extends NBTTagCompound {
 
 	@Override
 	public void setBoolean(@Nonnull String key, boolean value) {
-		if(constructing)super.setBoolean(key, value);
+		if (constructing) super.setBoolean(key, value);
 		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setByte(@Nonnull String key, byte value) {
-		if(constructing)super.setByte(key, value);
+		if (constructing) super.setByte(key, value);
 		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setByteArray(@Nonnull String key, @Nonnull byte[] value) {
-		if(constructing)super.setByteArray(key, value);
+		if (constructing) super.setByteArray(key, value);
 		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setDouble(@Nonnull String key, double value) {
-		if(constructing)super.setDouble(key, value);
+		if (constructing) super.setDouble(key, value);
 		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setFloat(@Nonnull String key, float value) {
-		if(constructing)super.setFloat(key, value);
+		if (constructing) super.setFloat(key, value);
 		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setIntArray(@Nonnull String key, @Nonnull int[] value) {
-		if(constructing)super.setIntArray(key, value);
+		if (constructing) super.setIntArray(key, value);
 		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setInteger(@Nonnull String key, int value) {
-		if(constructing)super.setInteger(key, value);
+		if (constructing) super.setInteger(key, value);
 		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setLong(@Nonnull String key, long value) {
-		if(constructing)super.setLong(key, value);
+		if (constructing) super.setLong(key, value);
 		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setShort(@Nonnull String key, short value) {
-		if(constructing)super.setShort(key, value);
+		if (constructing) super.setShort(key, value);
 		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setString(@Nonnull String key, String value) {
-		if(constructing)super.setString(key, value);
+		if (constructing) super.setString(key, value);
 		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setTag(@Nonnull String key, @Nonnull NBTBase value) {
-		if(constructing)super.setTag(key, value);
+		if (constructing) super.setTag(key, value);
 		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setUniqueId(String key, UUID value) {
-		if(constructing)super.setUniqueId(key, value);
+		if (constructing) super.setUniqueId(key, value);
 		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void merge(NBTTagCompound other) {
-		if(constructing)super.merge(other);
+		if (constructing) super.merge(other);
 		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void removeTag(@Nonnull String key) {
-		if(constructing)super.removeTag(key);
+		if (constructing) super.removeTag(key);
 		else throw new UnsupportedOperationException();
 	}
 }

--- a/common/logisticspipes/utils/FinalNBTTagCompound.java
+++ b/common/logisticspipes/utils/FinalNBTTagCompound.java
@@ -9,11 +9,12 @@ import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 
 public class FinalNBTTagCompound extends NBTTagCompound {
-
+	private boolean constructing;
 	public FinalNBTTagCompound(NBTTagCompound base) {
 		super();
-		NBTTagCompound copy = base.copy();
-		tagMap.putAll(copy.tagMap);
+		constructing = true;
+		super.merge(base);
+		constructing = false;
 	}
 
 	@Nonnull
@@ -24,72 +25,85 @@ public class FinalNBTTagCompound extends NBTTagCompound {
 
 	@Override
 	public void setBoolean(@Nonnull String key, boolean value) {
-		throw new UnsupportedOperationException();
+		if(constructing)super.setBoolean(key, value);
+		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setByte(@Nonnull String key, byte value) {
-		throw new UnsupportedOperationException();
+		if(constructing)super.setByte(key, value);
+		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setByteArray(@Nonnull String key, @Nonnull byte[] value) {
-		throw new UnsupportedOperationException();
+		if(constructing)super.setByteArray(key, value);
+		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setDouble(@Nonnull String key, double value) {
-		throw new UnsupportedOperationException();
+		if(constructing)super.setDouble(key, value);
+		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setFloat(@Nonnull String key, float value) {
-		throw new UnsupportedOperationException();
+		if(constructing)super.setFloat(key, value);
+		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setIntArray(@Nonnull String key, @Nonnull int[] value) {
-		throw new UnsupportedOperationException();
+		if(constructing)super.setIntArray(key, value);
+		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setInteger(@Nonnull String key, int value) {
-		throw new UnsupportedOperationException();
+		if(constructing)super.setInteger(key, value);
+		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setLong(@Nonnull String key, long value) {
-		throw new UnsupportedOperationException();
+		if(constructing)super.setLong(key, value);
+		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setShort(@Nonnull String key, short value) {
-		throw new UnsupportedOperationException();
+		if(constructing)super.setShort(key, value);
+		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setString(@Nonnull String key, String value) {
-		throw new UnsupportedOperationException();
+		if(constructing)super.setString(key, value);
+		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setTag(@Nonnull String key, @Nonnull NBTBase value) {
-		throw new UnsupportedOperationException();
+		if(constructing)super.setTag(key, value);
+		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setUniqueId(String key, UUID value) {
-		throw new UnsupportedOperationException();
+		if(constructing)super.setUniqueId(key, value);
+		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void merge(NBTTagCompound other) {
-		throw new UnsupportedOperationException();
+		if(constructing)super.merge(other);
+		else throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void removeTag(@Nonnull String key) {
-		throw new UnsupportedOperationException();
+		if(constructing)super.removeTag(key);
+		else throw new UnsupportedOperationException();
 	}
-
 }

--- a/resources/META-INF/lp_at.cfg
+++ b/resources/META-INF/lp_at.cfg
@@ -6,3 +6,4 @@ protected net.minecraft.inventory.Container field_94536_g #dragEvent
 protected net.minecraft.inventory.Container field_94535_f #dragMode
 protected net.minecraft.inventory.Container field_94537_h #dragSlots
 public net.minecraft.client.renderer.EntityRenderer func_78479_a(FI)V #setupCameraTransform
+public net.minecraft.nbt.NBTTagCompound field_74784_a #tagMap

--- a/resources/META-INF/lp_at.cfg
+++ b/resources/META-INF/lp_at.cfg
@@ -6,4 +6,3 @@ protected net.minecraft.inventory.Container field_94536_g #dragEvent
 protected net.minecraft.inventory.Container field_94535_f #dragMode
 protected net.minecraft.inventory.Container field_94537_h #dragSlots
 public net.minecraft.client.renderer.EntityRenderer func_78479_a(FI)V #setupCameraTransform
-public net.minecraft.nbt.NBTTagCompound field_74784_a #tagMap


### PR DESCRIPTION
Fixes crashes with items with NBT.

`Caused by: java.lang.UnsupportedOperationException
	at logisticspipes.utils.FinalNBTTagCompound.func_74782_a(FinalNBTTagCompound.java:75)
	at net.minecraft.nbt.NBTTagCompound.func_179237_a(NBTTagCompound.java:530)
	at logisticspipes.utils.FinalNBTTagCompound.<init>(FinalNBTTagCompound.java:14)
	at logisticspipes.utils.item.ItemIdentifier.get(ItemIdentifier.java:353)
        ....`

My crash with provider pipe and renamed item (in debugging environment):
[crash-2019-09-03_18.40.30-server.txt](https://github.com/RS485/LogisticsPipes/files/3570700/crash-2019-09-03_18.40.30-server.txt)
`