### PR TITLE
Fix for traceless insertion of items by Supplier pipe + PatternUpgrade

### DIFF
--- a/common/logisticspipes/utils/InventoryUtil.java
+++ b/common/logisticspipes/utils/InventoryUtil.java
@@ -185,7 +185,7 @@ public class InventoryUtil implements IInventoryUtil, ISpecialInsertion {
 	@Override
 	public int addToSlot(ItemStack stack, int slot) {
 		int wanted = stack.getCount();
-		ItemStack rest = _inventory.insertItem(slot, stack, true);
+		ItemStack rest = _inventory.insertItem(slot, stack, false);
 		return wanted - rest.getCount();
 	}
 }


### PR DESCRIPTION
Supplier pipe with installed Placement Rules Upgrade deletes arriving items.
Chassis pipe with Active Supplier Module + Placement Rules Upgrade does the same.

here "simulate" instead of "doAdd"