### PR TITLE
Multiple GL11 flag resets. Fix #1441

### DIFF
--- a/common/logisticspipes/gui/GuiCraftingPipe.java
+++ b/common/logisticspipes/gui/GuiCraftingPipe.java
@@ -307,6 +307,8 @@ public class GuiCraftingPipe extends ModuleBaseGui {
 	@Override
 	protected void drawGuiContainerForegroundLayer(int par1, int par2) {
 		super.drawGuiContainerForegroundLayer(par1, par2);
+		GL11.glDisable(GL11.GL_LIGHTING);
+		GlStateManager.color(1.0F,1.0F,1.0F,1.0F);
 		mc.fontRenderer.drawString(StringUtils.translate(GuiCraftingPipe.PREFIX + "Inputs"), 18, 7, 0x404040);
 		mc.fontRenderer.drawString(StringUtils.translate(GuiCraftingPipe.PREFIX + "Inventory"), 10, ySize - 93, 0x404040);
 
@@ -340,6 +342,7 @@ public class GuiCraftingPipe extends ModuleBaseGui {
 			mc.fontRenderer.drawString(StringUtils.translate(GuiCraftingPipe.PREFIX + "Priority") + ":", 123, 95, 0x404040);
 			mc.fontRenderer.drawString("" + _pipe.priority, 143 - (mc.fontRenderer.getStringWidth("" + _pipe.priority) / 2), 107, 0x404040);
 		}
+		GL11.glEnable(GL11.GL_LIGHTING);
 	}
 
 	@Override

--- a/common/logisticspipes/utils/gui/LogisticsBaseGuiScreen.java
+++ b/common/logisticspipes/utils/gui/LogisticsBaseGuiScreen.java
@@ -302,13 +302,13 @@ public abstract class LogisticsBaseGuiScreen extends GuiContainer implements ISu
 				renderAtTheEnd.add(() -> {
 					GL11.glDisable(GL11.GL_DEPTH_TEST);
 					GL11.glDisable(GL11.GL_LIGHTING);
-					GuiGraphics.drawGuiBackGround(mc, posX, posY, posX + 60, posY + 52, zLevel, true, true, true, true, true);
+					GuiGraphics.drawGuiBackGround(mc, posX, posY, posX + 61, posY + 47, zLevel, true, true, true, true, true);
 					GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 					final String PREFIX = "gui.crafting.";
-					mc.fontRenderer.drawString(StringUtils.translate(PREFIX + "OreDict"), posX + 4, posY + 8, (!resource.use_od ? 0x404040 : 0xFF4040));
-					mc.fontRenderer.drawString(StringUtils.translate(PREFIX + "IgnDamage"), posX + 4, posY + 18, (!resource.ignore_dmg ? 0x404040 : 0x40FF40));
-					mc.fontRenderer.drawString(StringUtils.translate(PREFIX + "IgnNBT"), posX + 4, posY + 28, (!resource.ignore_nbt ? 0x404040 : 0x4040FF));
-					mc.fontRenderer.drawString(StringUtils.translate(PREFIX + "OrePrefix"), posX + 4, posY + 38, (!resource.use_category ? 0x404040 : 0x7F7F40));
+					mc.fontRenderer.drawString(StringUtils.translate(PREFIX + "OreDict"), posX + 5, posY + 5, (!resource.use_od ? 0x404040 : 0xFF4040));
+					mc.fontRenderer.drawString(StringUtils.translate(PREFIX + "IgnDamage"), posX + 5, posY + 15, (!resource.ignore_dmg ? 0x404040 : 0x40FF40));
+					mc.fontRenderer.drawString(StringUtils.translate(PREFIX + "IgnNBT"), posX + 5, posY + 25, (!resource.ignore_nbt ? 0x404040 : 0x4040FF));
+					mc.fontRenderer.drawString(StringUtils.translate(PREFIX + "OrePrefix"), posX + 5, posY + 35, (!resource.use_category ? 0x404040 : 0x7F7F40));
 					GL11.glEnable(GL11.GL_LIGHTING);
 					GL11.glEnable(GL11.GL_DEPTH_TEST);
 				});
@@ -442,9 +442,9 @@ public abstract class LogisticsBaseGuiScreen extends GuiContainer implements ISu
 			final int posX = fuzzySlot.getX() + guiLeft;
 			final int posY = fuzzySlot.getY() + 17 + guiTop;
 			int sel = -1;
-			if (par1 >= posX + 4 && par1 <= posX + 60 - 4) {
-				if (par2 >= posY + 4 && par2 <= posY + 52 - 4) {
-					sel = (par2 - posY - 4) / 11;
+			if (par1 >= posX + 5 && par1 <= posX + 56) {
+				if (par2 >= posY + 5 && par2 <= posY + 45) {
+					sel = (par2 - posY - 4) / 10;
 				}
 			}
 			DictResource resource = fuzzySlot.getFuzzyFlags();

--- a/common/logisticspipes/utils/gui/LogisticsBaseGuiScreen.java
+++ b/common/logisticspipes/utils/gui/LogisticsBaseGuiScreen.java
@@ -21,6 +21,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.inventory.ClickType;
 import net.minecraft.inventory.Container;
@@ -271,6 +272,7 @@ public abstract class LogisticsBaseGuiScreen extends GuiContainer implements ISu
 				Gui.drawRect(x1 + 8, y1 + 16, x1 + 17, y1 + 17, 0xFF7F7F40);
 				Gui.drawRect(x1 + 16, y1 + 8, x1 + 17, y1 + 17, 0xFF7F7F40);
 			}
+			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 			GL11.glEnable(GL11.GL_LIGHTING);
 			final boolean mouseOver = this.isMouseOverSlot(slot, currentDrawScreenMouseX, currentDrawScreenMouseY);
 			if (mouseOver) {
@@ -301,10 +303,11 @@ public abstract class LogisticsBaseGuiScreen extends GuiContainer implements ISu
 					GL11.glDisable(GL11.GL_DEPTH_TEST);
 					GL11.glDisable(GL11.GL_LIGHTING);
 					GuiGraphics.drawGuiBackGround(mc, posX, posY, posX + 60, posY + 52, zLevel, true, true, true, true, true);
+					GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 					final String PREFIX = "gui.crafting.";
-					mc.fontRenderer.drawString(StringUtils.translate(PREFIX + "OreDict"), posX + 4, posY + 4, (!resource.use_od ? 0x404040 : 0xFF4040));
-					mc.fontRenderer.drawString(StringUtils.translate(PREFIX + "IgnDamage"), posX + 4, posY + 14, (!resource.ignore_dmg ? 0x404040 : 0x40FF40));
-					mc.fontRenderer.drawString(StringUtils.translate(PREFIX + "IgnNBT"), posX + 4, posY + 26, (!resource.ignore_nbt ? 0x404040 : 0x4040FF));
+					mc.fontRenderer.drawString(StringUtils.translate(PREFIX + "OreDict"), posX + 4, posY + 8, (!resource.use_od ? 0x404040 : 0xFF4040));
+					mc.fontRenderer.drawString(StringUtils.translate(PREFIX + "IgnDamage"), posX + 4, posY + 18, (!resource.ignore_dmg ? 0x404040 : 0x40FF40));
+					mc.fontRenderer.drawString(StringUtils.translate(PREFIX + "IgnNBT"), posX + 4, posY + 28, (!resource.ignore_nbt ? 0x404040 : 0x4040FF));
 					mc.fontRenderer.drawString(StringUtils.translate(PREFIX + "OrePrefix"), posX + 4, posY + 38, (!resource.use_category ? 0x404040 : 0x7F7F40));
 					GL11.glEnable(GL11.GL_LIGHTING);
 					GL11.glEnable(GL11.GL_DEPTH_TEST);


### PR DESCRIPTION
Reset color and flags with GlStateManager and GL11#glEnable/glDisable in multiple points in  both the base LogisticsBaseGuiScreen.java class as well as the GuiCraftingPipe.java class to atone for some GlStateManager leaks that have yet to be identified.
This will fix the current problem but this is not a complete fix, this is just a simple hack.
