### PR TITLE
Change nextOrientation() to protected

### DIFF
--- a/common/logisticspipes/pipes/PipeLogisticsChassis.java
+++ b/common/logisticspipes/pipes/PipeLogisticsChassis.java
@@ -155,7 +155,7 @@ public abstract class PipeLogisticsChassis extends CoreRoutedPipe implements ICr
 		}
 	}
 
-	private void nextOrientation() {
+	protected void nextOrientation() {
 		final SingleAdjacent pointedAdjacent = getPointedAdjacent();
 		Pair<NeighborTileEntity<TileEntity>, ConnectionType> newNeighbor;
 		if (pointedAdjacent == null) {


### PR DESCRIPTION
Required for CraftingManager from Logistics Bridge, as it extends PipeLogisticsChassis