### PR TITLE
Fixed some issues with adjacency cache

### DIFF
--- a/common/logisticspipes/pipes/PipeItemsCraftingLogistics.java
+++ b/common/logisticspipes/pipes/PipeItemsCraftingLogistics.java
@@ -118,6 +118,12 @@ public class PipeItemsCraftingLogistics extends CoreRoutedPipe implements ICraft
 	}
 
 	@Override
+	public void firstInitialiseTick() {
+		super.firstInitialiseTick();
+		updateAdjacentCache();
+	}
+
+	@Override
 	public TextureType getCenterTexture() {
 		return Textures.LOGISTICSPIPE_CRAFTER_TEXTURE;
 	}

--- a/common/logisticspipes/pipes/PipeItemsCraftingLogistics.java
+++ b/common/logisticspipes/pipes/PipeItemsCraftingLogistics.java
@@ -55,6 +55,8 @@ import logisticspipes.utils.IHavePriority;
 import logisticspipes.utils.PlayerCollectionList;
 import logisticspipes.utils.item.ItemIdentifier;
 import logisticspipes.utils.item.ItemIdentifierStack;
+import network.rs485.logisticspipes.connection.Adjacent;
+import network.rs485.logisticspipes.connection.SingleAdjacent;
 
 @CCType(name = "LogisticsPipes:Crafting")
 public class PipeItemsCraftingLogistics extends CoreRoutedPipe implements ICraftItems, IRequireReliableTransport, IHeadUpDisplayRendererProvider, IChangeListener, IOrderManagerContentReceiver, IHavePriority {
@@ -89,6 +91,29 @@ public class PipeItemsCraftingLogistics extends CoreRoutedPipe implements ICraft
 		super.enabledUpdateEntity();
 		if (doContentUpdate) {
 			checkContentUpdate();
+		}
+	}
+
+	/**
+	 * Updates pointedAdjacent on {@link CoreRoutedPipe}.
+	 */
+	@Override
+	protected void updateAdjacentCache() {
+		super.updateAdjacentCache();
+		final Adjacent adjacent = getAdjacent();
+		if (adjacent instanceof SingleAdjacent) {
+			setPointedAdjacent(((SingleAdjacent) adjacent));
+		} else {
+			final SingleAdjacent oldPointedAdjacent = getPointedAdjacent();
+			SingleAdjacent newPointedAdjacent = null;
+			if (oldPointedAdjacent != null) {
+				// update pointed adjacent with connection type or reset it
+				newPointedAdjacent = adjacent.optionalGet(oldPointedAdjacent.getDir()).map(connectionType -> new SingleAdjacent(this, oldPointedAdjacent.getDir(), connectionType)).orElse(null);
+			}
+			if (newPointedAdjacent == null) {
+				newPointedAdjacent = adjacent.neighbors().entrySet().stream().findAny().map(connectedNeighbor -> new SingleAdjacent(this, connectedNeighbor.getKey().getDirection(), connectedNeighbor.getValue())).orElse(null);
+			}
+			setPointedAdjacent(newPointedAdjacent);
 		}
 	}
 

--- a/common/logisticspipes/pipes/PipeLogisticsChassis.java
+++ b/common/logisticspipes/pipes/PipeLogisticsChassis.java
@@ -700,6 +700,12 @@ public abstract class PipeLogisticsChassis extends CoreRoutedPipe
 	}
 
 	@Override
+	public void firstInitialiseTick() {
+		super.firstInitialiseTick();
+		updateAdjacentCache();
+	}
+
+	@Override
 	public boolean canCraft(IResource toCraft) {
 		for (int i = 0; i < getChassisSize(); i++) {
 			LogisticsModule x = getSubModule(i);


### PR DESCRIPTION
Due to missing the same update function present in Chassis Pipes, pointedAdjacent for crafting pipes never gets set, causing #1581. 

This doesn't add the pointedAjdacent switching feature when wrenching the pipe, which might be desireable.

Perhaps it would be beneficial to create a new class between CoreRoutedPipe and all directional pipes that share this sort of functionality, in order to avoid the code duplication this comes with. I.e. CoreRoutedPipe -> PointedPipe -> PipeLogisticsChassis.