### PR TITLE
Use firstOrNull() instead of first(). Fixes #1588

### DIFF
--- a/src/main/kotlin/network/rs485/logisticspipes/module/AsyncExtractorModule.kt
+++ b/src/main/kotlin/network/rs485/logisticspipes/module/AsyncExtractorModule.kt
@@ -127,7 +127,7 @@ class AsyncExtractorModule(
         get() = upgradeManager.let { um -> CoreRoutedPipe.ItemSendMode.Fast.takeIf { um.itemExtractionUpgrade > 0 } }
             ?: CoreRoutedPipe.ItemSendMode.Normal
     private val connectedInventory: IInventoryUtil?
-        get() = _service?.availableSneakyInventories(sneakyDirection)?.first()
+        get() = _service?.availableSneakyInventories(sneakyDirection)?.firstOrNull()
 
     @ExperimentalCoroutinesApi
     override fun tickSetup(): Channel<Pair<Int, ItemStack>>? =


### PR DESCRIPTION
Switch to firstOrNull() to prevent potential crashes