### PR TITLE
Fix #1576

### DIFF
--- a/common/logisticspipes/pipes/basic/fluid/FluidRoutedPipe.java
+++ b/common/logisticspipes/pipes/basic/fluid/FluidRoutedPipe.java
@@ -111,7 +111,7 @@ public abstract class FluidRoutedPipe extends CoreRoutedPipe {
 		return new WorldCoordinatesWrapper(container).allNeighborTileEntities().stream()
 				.filter(adjacent -> isConnectableTank(adjacent.getTileEntity(), adjacent.getDirection(), flag))
 				.map(adjacent -> new Triplet<>(
-						SimpleServiceLocator.tankUtilFactory.getTankUtilForTE(adjacent.getTileEntity(), adjacent.getDirection()),
+						SimpleServiceLocator.tankUtilFactory.getTankUtilForTE(adjacent.getTileEntity(), adjacent.getDirection().getOpposite()),
 						adjacent.getTileEntity(),
 						adjacent.getDirection()))
 				.filter(triplet -> triplet.getValue1() != null)


### PR DESCRIPTION
Confirmed behavior through use of  GT shutter module that blocks all interactions. Shutter on the opposite side of a pipes connection stopped the pipe from working.

The pipe checked on the side where itself was connected, not the opposite as it needed to.

To clarify: If a pipe connectes to a tank on the pipes SOUTH side, it would also access the tank from the tanks SOUTH side. But for the Tank, the pipe is connected to NORTH. Thus the pipe was simply checking the opposite side of the tank, not the one it was connected to.